### PR TITLE
support external training data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ NB_GID = $(shell id -g)
 LIMIT = 10000
 ARCHITECTURE = CustomBidLSTM_CRF
 EMBEDDING = https://github.com/elifesciences/sciencebeam-models/releases/download/v0.0.1/glove.6B.50d.txt.gz
+INPUT_PATH = https://github.com/elifesciences/sciencebeam-datasets/releases/download/v0.0.1/delft-grobid-header-060518.train.gz
 WORD_LSTM_UNITS = 100
 FEATURE_INDICES =
 FEATURE_EMBEDDING_SIZE = 0
@@ -122,6 +123,7 @@ grobid-train-header:
 		--feature-indices="$(FEATURE_INDICES)" \
 		--feature-embedding-size="$(FEATURE_EMBEDDING_SIZE)" \
 		--max-epoch="$(MAX_EPOCH)" \
+		--input="$(INPUT_PATH)" \
 		--output="$(MODEL_OUTPUT)" \
 		--limit="$(LIMIT)" \
 		--checkpoint="$(CHECKPOINT_OUTPUT)" \

--- a/sciencebeam_trainer_delft/download_manager.py
+++ b/sciencebeam_trainer_delft/download_manager.py
@@ -1,0 +1,47 @@
+import logging
+import os
+
+from sciencebeam_trainer_delft.utils import (
+    copy_file,
+    is_external_location,
+    is_gzip_filename,
+    strip_gzip_filename_ext
+)
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+DEFAULT_DOWNLOAD_DIR = 'data/download'
+
+
+class DownloadManager:
+    def __init__(self, download_dir: str = DEFAULT_DOWNLOAD_DIR):
+        self.download_dir = download_dir
+
+    def get_local_file(self, file_url: str, auto_uncompress: bool = True) -> str:
+        filename = os.path.basename(file_url)
+        if auto_uncompress and is_gzip_filename(filename):
+            filename = strip_gzip_filename_ext(filename)
+        return os.path.join(self.download_dir, filename)
+
+    def is_downloaded(self, file_url: str, auto_uncompress: bool = True) -> str:
+        download_file = self.get_local_file(file_url, auto_uncompress=auto_uncompress)
+        return os.path.exists(download_file)
+
+    def download(
+            self, file_url: str,
+            auto_uncompress: bool = True,
+            skip_if_downloaded: bool = True) -> str:
+        download_file = self.get_local_file(file_url, auto_uncompress=auto_uncompress)
+        if skip_if_downloaded and self.is_downloaded(file_url, auto_uncompress=auto_uncompress):
+            LOGGER.info('file already downloaded: %s', file_url)
+        else:
+            LOGGER.info('copying %s to %s', file_url, download_file)
+            copy_file(file_url, download_file)
+        return download_file
+
+    def download_if_url(self, file_url_or_path: str, **kwargs) -> str:
+        if is_external_location(file_url_or_path):
+            return self.download(file_url_or_path, **kwargs)
+        return file_url_or_path

--- a/tests/download_manager_test.py
+++ b/tests/download_manager_test.py
@@ -1,0 +1,50 @@
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+from py._path.local import LocalPath
+
+import sciencebeam_trainer_delft.download_manager as embedding_manager_module
+from sciencebeam_trainer_delft.download_manager import (
+    DownloadManager
+)
+
+
+EMBEDDING_NAME_1 = 'embedding1'
+EXTERNAL_TXT_URL_1 = 'http://host/%s.txt' % EMBEDDING_NAME_1
+EXTERNAL_TXT_GZ_URL_1 = EXTERNAL_TXT_URL_1 + '.gz'
+
+
+@pytest.fixture(name='copy_file_mock', autouse=True)
+def _copy_file_mock():
+    with patch.object(embedding_manager_module, 'copy_file') as mock:
+        yield mock
+
+@pytest.fixture(name='data_dir')
+def _data_dir(tmpdir):
+    return tmpdir.join('data')
+
+
+@pytest.fixture(name='download_dir')
+def _download_dir(data_dir):
+    return data_dir.join('download')
+
+
+class TestDownloadManager:
+    def test_should_download(
+            self,
+            copy_file_mock: MagicMock,
+            download_dir: LocalPath):
+        download_file = download_dir.join(os.path.basename(EXTERNAL_TXT_URL_1))
+        download_manager = DownloadManager(download_dir=download_dir)
+        assert download_manager.download(EXTERNAL_TXT_URL_1) == download_file
+        copy_file_mock.assert_called_with(EXTERNAL_TXT_URL_1, download_file)
+
+    def test_should_unzip_embedding(
+            self,
+            copy_file_mock: MagicMock,
+            download_dir: LocalPath):
+        download_file = download_dir.join(os.path.basename(EXTERNAL_TXT_URL_1))
+        download_manager = DownloadManager(download_dir=download_dir)
+        assert download_manager.download(EXTERNAL_TXT_GZ_URL_1) == download_file
+        copy_file_mock.assert_called_with(EXTERNAL_TXT_GZ_URL_1, download_file)

--- a/tests/embedding_manager_test.py
+++ b/tests/embedding_manager_test.py
@@ -1,10 +1,8 @@
-import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from py._path.local import LocalPath
 
-import sciencebeam_trainer_delft.embedding_manager as embedding_manager_module
 from sciencebeam_trainer_delft.embedding_manager import (
     EmbeddingManager
 )
@@ -13,56 +11,48 @@ from sciencebeam_trainer_delft.embedding_manager import (
 EMBEDDING_NAME_1 = 'embedding1'
 EXTERNAL_TXT_URL_1 = 'http://host/%s.txt' % EMBEDDING_NAME_1
 EXTERNAL_TXT_GZ_URL_1 = EXTERNAL_TXT_URL_1 + '.gz'
-
-
-@pytest.fixture(name='copy_file_mock', autouse=True)
-def _copy_file_mock():
-    with patch.object(embedding_manager_module, 'copy_file') as mock:
-        yield mock
+DOWNLOAD_PATH_1 = '/path/to/download/%s.txt' % EMBEDDING_NAME_1
 
 
 @pytest.fixture(name='embedding_registry_path')
-def _embedding_registry_path(tmpdir):
+def _embedding_registry_path(tmpdir: LocalPath):
     return tmpdir.join('embedding-registry.json')
 
 
-@pytest.fixture(name='data_dir')
-def _data_dir(tmpdir):
-    return tmpdir.join('data')
-
-
-@pytest.fixture(name='download_dir')
-def _download_dir(data_dir):
-    return data_dir.join('download')
+@pytest.fixture(name='download_manager')
+def _download_manager():
+    download_manager = MagicMock(name='download_manager')
+    download_manager.download_if_url.return_value = DOWNLOAD_PATH_1
+    return download_manager
 
 
 class TestEmbeddingManager:
     def test_should_download_and_install_embedding(
             self,
-            copy_file_mock: MagicMock,
-            embedding_registry_path: LocalPath,
-            download_dir: LocalPath):
-        download_file = download_dir.join(os.path.basename(EXTERNAL_TXT_URL_1))
-        embedding_manager = EmbeddingManager(embedding_registry_path, download_dir=download_dir)
+            download_manager: MagicMock,
+            embedding_registry_path: LocalPath):
+        embedding_manager = EmbeddingManager(
+            embedding_registry_path, download_manager=download_manager
+        )
         embedding_manager.download_and_install_embedding(EXTERNAL_TXT_URL_1)
-        copy_file_mock.assert_called_with(EXTERNAL_TXT_URL_1, download_file)
+        download_manager.download_if_url.assert_called_with(EXTERNAL_TXT_URL_1)
 
         embedding_config = embedding_manager.get_embedding_config(EMBEDDING_NAME_1)
         assert embedding_config
         assert embedding_config['name'] == EMBEDDING_NAME_1
-        assert embedding_config['path'] == str(download_file)
+        assert embedding_config['path'] == DOWNLOAD_PATH_1
 
     def test_should_unzip_embedding(
             self,
-            copy_file_mock: MagicMock,
-            embedding_registry_path: LocalPath,
-            download_dir: LocalPath):
-        download_file = download_dir.join(os.path.basename(EXTERNAL_TXT_URL_1))
-        embedding_manager = EmbeddingManager(embedding_registry_path, download_dir=download_dir)
+            download_manager: MagicMock,
+            embedding_registry_path: LocalPath):
+        embedding_manager = EmbeddingManager(
+            embedding_registry_path, download_manager=download_manager
+        )
         embedding_manager.download_and_install_embedding(EXTERNAL_TXT_GZ_URL_1)
-        copy_file_mock.assert_called_with(EXTERNAL_TXT_GZ_URL_1, download_file)
+        download_manager.download_if_url.assert_called_with(EXTERNAL_TXT_GZ_URL_1)
 
         embedding_config = embedding_manager.get_embedding_config(EMBEDDING_NAME_1)
         assert embedding_config
         assert embedding_config['name'] == EMBEDDING_NAME_1
-        assert embedding_config['path'] == str(download_file)
+        assert embedding_config['path'] == DOWNLOAD_PATH_1

--- a/tests/grobid_trainer_test.py
+++ b/tests/grobid_trainer_test.py
@@ -1,7 +1,7 @@
 import json
 import os
 from functools import partial
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import pytest
 from py._path.local import LocalPath
@@ -51,6 +51,18 @@ def _embedding_class(embedding_registry_path: str):
         yield mock
 
 
+@pytest.fixture(name='default_args')
+def _default_args(sample_train_file: str):
+    download_manager = MagicMock(name='download_manager')
+    download_manager.download_if_url.return_value = str(sample_train_file)
+    return dict(
+        model='header',
+        embeddings_name=EMBEDDING_NAME_1,
+        input_path=sample_train_file,
+        download_manager=download_manager
+    )
+
+
 class TestGrobidTrainer:
     class TestParseArgs:
         def test_should_require_arguments(self):
@@ -59,33 +71,25 @@ class TestGrobidTrainer:
 
     @pytest.mark.slow
     class TestEndToEnd:
-        def test_should_be_able_to_train_without_features(self, sample_train_file: str):
+        def test_should_be_able_to_train_without_features(self, default_args: dict):
             train(
-                model='header',
-                embeddings_name=EMBEDDING_NAME_1,
-                input_path=sample_train_file,
-                use_features=False
+                use_features=False,
+                **default_args
             )
 
-        def test_should_be_able_to_train_with_features(self, sample_train_file: str):
+        def test_should_be_able_to_train_with_features(self, default_args: dict):
             train(
-                model='header',
-                embeddings_name=EMBEDDING_NAME_1,
-                input_path=sample_train_file,
-                use_features=True
+                use_features=True,
+                **default_args
             )
 
-        def test_should_be_able_to_train_eval(self, sample_train_file: str):
+        def test_should_be_able_to_train_eval(self, default_args: dict):
             train_eval(
-                model='header',
-                embeddings_name=EMBEDDING_NAME_1,
-                input_path=sample_train_file
+                **default_args
             )
 
-        def test_should_be_able_to_train_eval_nfold(self, sample_train_file: str):
+        def test_should_be_able_to_train_eval_nfold(self, default_args: dict):
             train_eval(
-                model='header',
-                embeddings_name=EMBEDDING_NAME_1,
-                input_path=sample_train_file,
-                fold_count=2
+                fold_count=2,
+                **default_args
             )


### PR DESCRIPTION
allows to specify for example:

```bash
--input https://github.com/elifesciences/sciencebeam-datasets/releases/download/v0.0.1/delft-grobid-header-060518.train.gz
```

Which will automatically unzip the file.