### PR TITLE
fixed grobid-train-header args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ test: \
 	)
 
 
-grobid-train-header:
+grobid-train-header: .grobid-train-header-args
 	$(PYTHON) -m sciencebeam_trainer_delft.grobid_trainer \
 		$(_GROBID_TRAIN_ARGS)
 


### PR DESCRIPTION
missed adding dependency on `.grobid-train-header-args`