### PR TITLE
fixed default embedding manager registry path

### DIFF
--- a/sciencebeam_trainer_delft/wrapper.py
+++ b/sciencebeam_trainer_delft/wrapper.py
@@ -61,12 +61,12 @@ class Sequence(_Sequence):
         # initialise logging if not already initialised
         logging.basicConfig(level='INFO')
         LOGGER.debug('Sequence, args=%s, kwargs=%s', args, kwargs)
+        self.embedding_registry_path = embedding_registry_path or DEFAULT_EMBEDDINGS_PATH
         if embedding_manager is None:
             embedding_manager = EmbeddingManager(
-                path=embedding_registry_path,
+                path=self.embedding_registry_path,
                 download_manager=DownloadManager()
             )
-        self.embedding_registry_path = embedding_registry_path
         self.embedding_manager = embedding_manager
         super().__init__(*args, **kwargs)
         LOGGER.debug('use_features=%s', use_features)
@@ -304,7 +304,7 @@ class Sequence(_Sequence):
         LOGGER.info('embedding_name: %s', embedding_name)
         embeddings = Embeddings(
             embedding_name,
-            path=self.embedding_registry_path or DEFAULT_EMBEDDINGS_PATH,
+            path=self.embedding_registry_path,
             use_ELMo=model_config.use_ELMo,
             use_BERT=model_config.use_BERT
         )

--- a/tests/wrapper_test.py
+++ b/tests/wrapper_test.py
@@ -1,0 +1,14 @@
+from sciencebeam_trainer_delft.wrapper import (
+    Sequence,
+    DEFAULT_EMBEDDINGS_PATH
+)
+
+
+MODEL_NAME_1 = 'DummyModel1'
+
+
+class TestSequence:
+    def test_should_create_embedding_manager_with_default_regisry_path(self):
+        model = Sequence(MODEL_NAME_1)
+        assert model.embedding_registry_path == DEFAULT_EMBEDDINGS_PATH
+        assert model.embedding_manager.path == DEFAULT_EMBEDDINGS_PATH


### PR DESCRIPTION
since `embedding_registry_path` was not passed in, it was `None`