### PR TITLE
added missing manifest.in to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY requirements.dev.txt ./
 RUN if [ "${install_dev}" = "y" ]; then pip install -r requirements.dev.txt; fi
 
 COPY sciencebeam_trainer_delft ./sciencebeam_trainer_delft
-COPY setup.py ./
+COPY setup.py  MANIFEST.in ./
 
 COPY config/embedding-registry.json ./
 

--- a/Dockerfile.grobid
+++ b/Dockerfile.grobid
@@ -51,7 +51,7 @@ RUN pip install -r ${PROJECT_FOLDER}/requirements.delft.txt --no-deps
 COPY sciencebeam_trainer_delft ${PROJECT_FOLDER}/sciencebeam_trainer_delft
 
 # install into venv
-COPY setup.py ${PROJECT_FOLDER}/
+COPY setup.py MANIFEST.in ${PROJECT_FOLDER}/
 RUN pip install -e ${PROJECT_FOLDER} --no-deps
 
 # add embedding registry with download locations


### PR DESCRIPTION
The `MANIFEST.in` file is required when submitting jobs to the cloud (e.g. training)