### PR TITLE
bumps tensorflow to >=1.15.1,<2.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ WORKDIR ${PROJECT_FOLDER}
 
 ENV PATH=/root/.local/bin:${PATH}
 
-RUN pip install pip --upgrade
+COPY requirements.build.txt ./
+RUN pip install --user -r requirements.build.txt
 
 COPY requirements.txt ./
 RUN pip install --user -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ WORKDIR ${PROJECT_FOLDER}
 
 ENV PATH=/root/.local/bin:${PATH}
 
+RUN pip install pip --upgrade
+
 COPY requirements.txt ./
 RUN pip install --user -r requirements.txt
 

--- a/Dockerfile.grobid
+++ b/Dockerfile.grobid
@@ -11,7 +11,7 @@ RUN apt-get update \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install pip --upgrade
+RUN python3 -m pip install pip --upgrade
 
 # create virtual env (see also https://bugs.python.org/issue24875)
 ENV VENV=/opt/venv

--- a/Dockerfile.grobid
+++ b/Dockerfile.grobid
@@ -11,6 +11,8 @@ RUN apt-get update \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
+RUN pip install pip --upgrade
+
 # create virtual env (see also https://bugs.python.org/issue24875)
 ENV VENV=/opt/venv
 COPY requirements.build.txt ${PROJECT_FOLDER}/

--- a/notebooks/train-header.ipynb
+++ b/notebooks/train-header.ipynb
@@ -22,7 +22,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -c 'import tensorflow' 2> /dev/null || pip install \"tensorflow==1.12.0\""
+    "!python -c 'import tensorflow' 2> /dev/null || pip install \"tensorflow==1.15.2\""
    ]
   },
   {

--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -1,2 +1,3 @@
+pip==20.0.2
 setuptools==45.1.0
 wheel==0.33.6

--- a/requirements.cpu.txt
+++ b/requirements.cpu.txt
@@ -1,1 +1,1 @@
-tensorflow>=1.12.0,<2.0.0
+tensorflow>=1.15.1,<2.0.0


### PR DESCRIPTION
regarding the security issue [GHSA-977j-xj7q-2jr9
](https://github.com/elifesciences/sciencebeam-trainer-delft/network/alert/requirements.cpu.txt/tensorflow/open)