### PR TITLE
use md5 in downloaded files to avoid basename collision

### DIFF
--- a/sciencebeam_trainer_delft/utils/download_manager.py
+++ b/sciencebeam_trainer_delft/utils/download_manager.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from hashlib import md5
 from pathlib import Path
 
 from sciencebeam_trainer_delft.utils.io import (
@@ -20,7 +21,10 @@ class DownloadManager:
         self.download_dir = Path(download_dir)
 
     def get_local_file(self, file_url: str, auto_uncompress: bool = True) -> str:
-        filename = os.path.basename(file_url)
+        filename = '%s-%s' % (
+            md5(file_url.encode('utf-8')).hexdigest(),
+            os.path.basename(file_url)
+        )
         if auto_uncompress:
             compression_wrapper = get_compression_wrapper(filename)
             filename = compression_wrapper.strip_compression_filename_ext(filename)
@@ -39,7 +43,7 @@ class DownloadManager:
             local_file or self.get_local_file(file_url, auto_uncompress=auto_uncompress)
         )
         if skip_if_downloaded and self.is_downloaded(file_url, auto_uncompress=auto_uncompress):
-            LOGGER.info('file already downloaded: %s', file_url)
+            LOGGER.info('file already downloaded: %s (%s)', file_url, download_file)
         else:
             LOGGER.info('copying %s to %s', file_url, download_file)
             copy_file(file_url, download_file)

--- a/tests/utils/download_manager_test.py
+++ b/tests/utils/download_manager_test.py
@@ -31,15 +31,35 @@ def _download_dir(data_dir: Path):
     return data_dir.joinpath('download')
 
 
+@pytest.fixture(name='download_manager')
+def _download_manager(download_dir: Path):
+    return DownloadManager(download_dir=download_dir)
+
+
 class TestDownloadManager:
+    def test_get_local_file_should_return_same_path_for_same_urls(
+            self,
+            download_manager: DownloadManager):
+        assert (
+            download_manager.get_local_file(EXTERNAL_TXT_URL_1)
+            == download_manager.get_local_file(EXTERNAL_TXT_URL_1)
+        )
+
+    def test_get_local_file_should_return_different_path_for_different_url_paths(
+            self,
+            download_manager: DownloadManager):
+        assert (
+            download_manager.get_local_file('http://host1/file.txt')
+            != download_manager.get_local_file('http://host2/file.txt')
+        )
+
     def test_should_download(
             self,
             copy_file_mock: MagicMock,
-            download_dir: Path):
-        download_file = str(download_dir.joinpath(os.path.basename(EXTERNAL_TXT_URL_1)))
-        download_manager = DownloadManager(download_dir=download_dir)
-        assert download_manager.download(EXTERNAL_TXT_URL_1) == download_file
+            download_manager: DownloadManager):
+        download_file = download_manager.download(EXTERNAL_TXT_URL_1)
         copy_file_mock.assert_called_with(EXTERNAL_TXT_URL_1, download_file)
+        assert str(download_file).endswith(os.path.basename(EXTERNAL_TXT_URL_1))
 
     def test_should_download_using_passed_in_local_file(
             self,
@@ -55,8 +75,7 @@ class TestDownloadManager:
     def test_should_unzip_embedding(
             self,
             copy_file_mock: MagicMock,
-            download_dir: Path):
-        download_file = str(download_dir.joinpath(os.path.basename(EXTERNAL_TXT_URL_1)))
-        download_manager = DownloadManager(download_dir=download_dir)
-        assert download_manager.download(EXTERNAL_TXT_GZ_URL_1) == download_file
+            download_manager: DownloadManager):
+        download_file = download_manager.download(EXTERNAL_TXT_GZ_URL_1)
         copy_file_mock.assert_called_with(EXTERNAL_TXT_GZ_URL_1, download_file)
+        assert str(download_file).endswith(os.path.basename(EXTERNAL_TXT_URL_1))


### PR DESCRIPTION
previously it would have treated `http://host1/file` and `http://host2/file` the same and wouldn't download the file, thinking it already had downloaded it. This now adds the md5 of the URL to the local filename, therefore the local filename will be different.