### PR TITLE
only validate embedding in train mode

### DIFF
--- a/sciencebeam_trainer_delft/sequence_labelling/grobid_trainer.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/grobid_trainer.py
@@ -501,10 +501,10 @@ def run(args):
         embedding_manager.disable_embedding_lmdb_cache()
     if action in {Tasks.TRAIN, Tasks.TRAIN_EVAL}:
         embedding_name = embedding_manager.ensure_available(args.embedding)
+        LOGGER.info('embedding_name: %s', embedding_name)
+        embedding_manager.validate_embedding(embedding_name)
     else:
         embedding_name = embedding_manager.resolve_alias(args.embedding)
-    LOGGER.info('embedding_name: %s', embedding_name)
-    embedding_manager.validate_embedding(embedding_name)
 
     train_args = dict(
         model=model,


### PR DESCRIPTION
In other modes, the embedding will be loaded from the model config. Therefore it doesn't make sense to validate the passed in embedding.