### PR TITLE
added eval max sequence length for train_eval

### DIFF
--- a/sciencebeam_trainer_delft/sequence_labelling/data_generator.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/data_generator.py
@@ -239,6 +239,8 @@ class DataGenerator(keras.utils.Sequence):
             self.window_indices_and_offset = self.generate_stateless_window_indices_and_offset()
         elif stateful and self.input_window_stride:
             self.batch_window_indices_and_offset = self.generate_batch_window_indices_and_offset()
+        else:
+            self.log_window_config()
         if self.shuffle and self.input_window_stride and stateful:
             LOGGER.info('not shuffling between epochs as number of batch windows could change')
             self.shuffle = False
@@ -277,13 +279,27 @@ class DataGenerator(keras.utils.Sequence):
     def get_sequence_lengths(self) -> List[int]:
         return [len(item) for item in self.x]
 
+    def log_window_config(self):
+        LOGGER.info(
+            ' '.join([
+                'max sequence length: %s, input window stride: %s'
+                ' (%d samples -> %d batches) (name=%s)'
+            ]),
+            self.max_sequence_length,
+            self.input_window_stride,
+            len(self.x),
+            self.get_batch_count(),
+            self.name
+        )
+
     def generate_stateless_window_indices_and_offset(self):
         window_indices_and_offset = get_stateless_window_indices_and_offset(
             sequence_lengths=self.get_sequence_lengths(),
             window_stride=self.input_window_stride
         )
         LOGGER.info(
-            'input window size: %s (%d samples -> %s windows) (name=%s)',
+            'max sequence length: %s, input window stride: %s (%d samples -> %s windows) (name=%s)',
+            self.max_sequence_length,
             self.input_window_stride,
             len(self.x),
             len(window_indices_and_offset),
@@ -298,7 +314,11 @@ class DataGenerator(keras.utils.Sequence):
             batch_size=self.batch_size
         )
         LOGGER.info(
-            'input window size: %s (%d samples -> %d batches) (name=%s)',
+            ' '.join([
+                'max sequence length: %s, input window stride: %s'
+                ' (%d samples -> %d batches) (name=%s)'
+            ]),
+            self.max_sequence_length,
             self.input_window_stride,
             len(self.x),
             len(batch_window_indices_and_offset),

--- a/sciencebeam_trainer_delft/sequence_labelling/grobid_trainer.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/grobid_trainer.py
@@ -387,6 +387,7 @@ def train_eval(
         random_seed: int = DEFAULT_RANDOM_SEED,
         eval_input_paths: List[str] = None,
         eval_limit: int = None,
+        eval_max_sequence_length: int = None,
         max_sequence_length: int = 100,
         fold_count=1, max_epoch=100, batch_size=20,
         download_manager: DownloadManager = None,
@@ -410,6 +411,7 @@ def train_eval(
         embeddings_name=embeddings_name,
         embedding_manager=embedding_manager,
         max_sequence_length=max_sequence_length,
+        eval_max_sequence_length=eval_max_sequence_length,
         model_type=architecture,
         use_ELMo=use_ELMo,
         batch_size=batch_size,
@@ -853,6 +855,14 @@ def add_eval_input_arguments(parser: argparse.ArgumentParser):
             "This is mostly for testing to make evaluation faster."
         ])
     )
+    parser.add_argument(
+        "--eval-max-sequence-length",
+        type=int,
+        help=' '.join([
+            "Limit the number of documents to use for evaluation.",
+            "This is mostly for testing to make evaluation faster."
+        ])
+    )
 
 
 def add_tag_output_format_argument(parser: argparse.ArgumentParser, **kwargs):
@@ -1180,6 +1190,7 @@ class TrainEvalSubCommand(GrobidTrainerSubCommand):
             embeddings_name=embedding_name,
             eval_input_paths=args.eval_input,
             eval_limit=args.eval_limit,
+            eval_max_sequence_length=args.eval_max_sequence_length,
             **self.get_train_args(args)
         )
 


### PR DESCRIPTION
resolves https://github.com/elifesciences/issues/issues/5577

related to https://github.com/elifesciences/sciencebeam-trainer-delft/pull/142

Evaluation should not use the same max sequence length