### PR TITLE
added --eval-batch-size argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ python -m sciencebeam_trainer_delft.sequence_labelling.grobid_trainer \
     --limit="100" \
     --eval-input=https://github.com/elifesciences/sciencebeam-datasets/releases/download/v0.0.1/delft-grobid-0.5.6-header.test.gz \
     --eval-limit="100" \
+    --eval-batch-size="5" \
     --early-stopping-patience="3" \
     --max-epoch="50"
 ```

--- a/sciencebeam_trainer_delft/sequence_labelling/tagger.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tagger.py
@@ -49,7 +49,8 @@ class Tagger:
             embeddings=self.embeddings,
             tokenize=tokeniz,
             shuffle=False,
-            features=features
+            features=features,
+            name='predict_generator'
         )
 
         steps_done = 0

--- a/sciencebeam_trainer_delft/sequence_labelling/wrapper.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/wrapper.py
@@ -103,6 +103,7 @@ class Sequence(_Sequence):
             config_props: dict = None,
             training_props: dict = None,
             eval_max_sequence_length: int = None,
+            eval_batch_size: int = None,
             **kwargs):
         # initialise logging if not already initialised
         logging.basicConfig(level='INFO')
@@ -117,6 +118,7 @@ class Sequence(_Sequence):
         self.embeddings = None
         self.max_sequence_length = kwargs.get('max_sequence_length')
         self.eval_max_sequence_length = eval_max_sequence_length
+        self.eval_batch_size = eval_batch_size
         self.model_path = None
         super().__init__(*args, **kwargs)
         LOGGER.debug('use_features=%s', use_features)
@@ -279,7 +281,10 @@ class Sequence(_Sequence):
     def create_eval_data_generator(self, *args, **kwargs) -> DataGenerator:
         return DataGenerator(
             *args,
-            batch_size=self.training_config.batch_size,
+            batch_size=(
+                self.eval_batch_size
+                or self.training_config.batch_size
+            ),
             preprocessor=self.p,
             additional_token_feature_indices=self.model_config.additional_token_feature_indices,
             char_embed_size=self.model_config.char_embedding_size,
@@ -298,7 +303,8 @@ class Sequence(_Sequence):
         test_generator = self.create_eval_data_generator(
             x_test, y_test,
             features=features,
-            shuffle=False
+            shuffle=False,
+            name='test_generator'
         )
 
         prediction_result = get_model_results(


### PR DESCRIPTION
Because evaluation may not apply the maximum sequence length used for training, a smaller batch size was required to not run out of memory.