### PR TITLE
patch sklearn externals joblib (temporarily)

### DIFF
--- a/sciencebeam_trainer_delft/sequence_labelling/__init__.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/__init__.py
@@ -1,0 +1,1 @@
+import sciencebeam_trainer_delft.utils.sklearn_externals_patch  # noqa

--- a/sciencebeam_trainer_delft/utils/sklearn_externals_patch.py
+++ b/sciencebeam_trainer_delft/utils/sklearn_externals_patch.py
@@ -1,0 +1,7 @@
+# interim patch of sklearn externals
+# (can be removed after delft was updated)
+
+import joblib
+import sklearn.externals
+
+sklearn.externals.joblib = joblib

--- a/tests/sequence_labelling/__init__.py
+++ b/tests/sequence_labelling/__init__.py
@@ -1,0 +1,1 @@
+import sciencebeam_trainer_delft.utils.sklearn_externals_patch  # noqa


### PR DESCRIPTION
sklearn 0.23.0 no longer has `sklearn.externals.joblib` which would fail, because delft 0.5.6 is using it.