### PR TITLE
added link to /data from /opt/grobid

### DIFF
--- a/Dockerfile.grobid
+++ b/Dockerfile.grobid
@@ -62,8 +62,11 @@ COPY config/embedding-registry.json ${PROJECT_FOLDER}/
 # disable python warnings (and fix logging)
 ENV PYTHONWARNINGS="ignore"
 
+# link the data directory to /data
+# the current working directory will most likely be /opt/grobid
 RUN mkdir -p /data \
-    && ln -s /data ${PROJECT_FOLDER}/data
+    && ln -s /data ${PROJECT_FOLDER}/data \
+    && ln -s /data ./data
 VOLUME ["/data"]
 
 # remove libjep.so because we are providng our own version in the virtual env


### PR DESCRIPTION
this caused preloaded embeddings to be downloaded again (due to the changing working directory and using a relative `data` directory)