### PR TITLE
downgraded keras-bert to <0.85.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ h5py>=2.7.1
 unidecode>=1.0.22
 pydot>=1.2.4
 lmdb>=0.94
-keras-bert>=0.39.0
+keras-bert>=0.39.0,<0.85.0


### PR DESCRIPTION
keras-bert 0.85.0 requires Keras 2.4.3.
That should get upgraded separated and tested more thouroughly.