### PR TITLE
refactor data generator text feature

### DIFF
--- a/sciencebeam_trainer_delft/sequence_labelling/config.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/config.py
@@ -26,6 +26,7 @@ class ModelConfig(_ModelConfig):
             features_lstm_units: int = None,
             use_features_indices_input: bool = False,
             stateful: bool = False,
+            is_deprecated_padded_batch_text_list_enabled: bool = True,
             **kwargs):
         super().__init__(*args)
         self.use_word_embeddings = use_word_embeddings
@@ -40,6 +41,9 @@ class ModelConfig(_ModelConfig):
         self.features_lstm_units = features_lstm_units
         self.use_features_indices_input = use_features_indices_input
         self.stateful = stateful
+        self.is_deprecated_padded_batch_text_list_enabled = (
+            is_deprecated_padded_batch_text_list_enabled
+        )
         for key, val in kwargs.items():
             setattr(self, key, val)
 

--- a/sciencebeam_trainer_delft/sequence_labelling/data_generator.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/data_generator.py
@@ -391,6 +391,8 @@ class DataGenerator(keras.utils.Sequence):
         self.is_deprecated_padded_batch_text_list_enabled = (
             is_deprecated_padded_batch_text_list_enabled
         )
+        if is_deprecated_padded_batch_text_list_enabled:
+            LOGGER.warning('using deprecated padded batch_text_list')
 
     def get_sample_count(self) -> int:
         if self.window_indices_and_offset:

--- a/sciencebeam_trainer_delft/sequence_labelling/data_generator.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/data_generator.py
@@ -338,7 +338,7 @@ class DataGenerator(keras.utils.Sequence):
             additional_token_feature_indices: List[int] = None,
             text_feature_indices: List[int] = None,
             concatenated_embeddings_token_count: int = None,
-            is_deprecated_padded_batch_text_list_enabled: bool = True,
+            is_deprecated_padded_batch_text_list_enabled: bool = False,
             name: str = None):
         'Initialization'
         if use_word_embeddings is None:

--- a/sciencebeam_trainer_delft/sequence_labelling/data_generator.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/data_generator.py
@@ -160,7 +160,7 @@ def iter_batch_text_from_tokens_with_additional_token_features(
         additional_token_feature_indices: List[int]) -> List[List[List[str]]]:
     if not additional_token_feature_indices:
         return batch_tokens
-    return ([
+    return (
         [
             ' '.join([token] + [
                 token_features[additional_token_feature_index]
@@ -169,7 +169,7 @@ def iter_batch_text_from_tokens_with_additional_token_features(
             for token, token_features in zip(doc_tokens, doc_features)
         ]
         for doc_tokens, doc_features in zip(batch_tokens, batch_features)
-    ])
+    )
 
 
 def iter_batch_text_from_text_features(

--- a/sciencebeam_trainer_delft/sequence_labelling/tagger.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tagger.py
@@ -49,6 +49,9 @@ class Tagger:
                 self.model_config.concatenated_embeddings_token_count
             ),
             char_embed_size=self.model_config.char_embedding_size,
+            is_deprecated_padded_batch_text_list_enabled=(
+                self.model_config.is_deprecated_padded_batch_text_list_enabled
+            ),
             max_sequence_length=self.max_sequence_length,
             embeddings=self.embeddings,
             tokenize=tokeniz,

--- a/sciencebeam_trainer_delft/sequence_labelling/trainer.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/trainer.py
@@ -181,6 +181,9 @@ class Trainer(_Trainer):
                 self.model_config.concatenated_embeddings_token_count
             ),
             char_embed_size=self.model_config.char_embedding_size,
+            is_deprecated_padded_batch_text_list_enabled=(
+                self.model_config.is_deprecated_padded_batch_text_list_enabled
+            ),
             max_sequence_length=self.model_config.max_sequence_length,
             embeddings=self.embeddings,
             **kwargs

--- a/sciencebeam_trainer_delft/sequence_labelling/wrapper.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/wrapper.py
@@ -299,6 +299,9 @@ class Sequence(_Sequence):
                 self.model_config.concatenated_embeddings_token_count
             ),
             char_embed_size=self.model_config.char_embedding_size,
+            is_deprecated_padded_batch_text_list_enabled=(
+                self.model_config.is_deprecated_padded_batch_text_list_enabled
+            ),
             max_sequence_length=self.eval_max_sequence_length,
             embeddings=self.embeddings,
             **kwargs

--- a/tests/sequence_labelling/data_generator_test.py
+++ b/tests/sequence_labelling/data_generator_test.py
@@ -12,6 +12,7 @@ from sciencebeam_trainer_delft.sequence_labelling.data_generator import (
     left_pad_batch_values,
     get_tokens_from_text_features,
     iter_batch_text_list,
+    iter_batch_tokens_by_token_index,
     get_stateless_window_indices_and_offset,
     get_batch_window_indices_and_offset,
     DataGenerator,
@@ -305,6 +306,67 @@ class TestIterBatchTextList:
                 text_feature_indices=text_feature_indices
             )) == expected_batch_text_list
         )
+
+
+class TestIterBatchTokensByTokenIndex:
+    def test_should_return_passed_in_text_if_zero_token_count(self):
+        batch_text_list = [
+            [
+                ' '.join([WORD_1, WORD_2, WORD_3]),
+                ' '.join([WORD_3, WORD_4])
+            ]
+        ]
+        expected_batch_tokens_list = [batch_text_list]
+        assert list(iter_batch_tokens_by_token_index(
+            batch_text_list=batch_text_list,
+            concatenated_embeddings_token_count=0
+        )) == expected_batch_tokens_list
+
+    def test_should_not_split_text_if_already_tokenized_and_only_one_token(self):
+        batch_text_list = [
+            [
+                ' '.join([WORD_1, WORD_2, WORD_3]),
+                ' '.join([WORD_3, WORD_4])
+            ]
+        ]
+        expected_batch_tokens_list = [batch_text_list]
+        assert list(iter_batch_tokens_by_token_index(
+            batch_text_list=batch_text_list,
+            concatenated_embeddings_token_count=1,
+            text_is_token=True
+        )) == expected_batch_tokens_list
+
+    def test_should_split_text_and_extract_first_token(self):
+        batch_text_list = [
+            [
+                ' '.join([WORD_1, WORD_2, WORD_3]),
+                ' '.join([WORD_3, WORD_4])
+            ]
+        ]
+        expected_batch_tokens_list = [
+            [[WORD_1, WORD_3]]
+        ]
+        assert list(iter_batch_tokens_by_token_index(
+            batch_text_list=batch_text_list,
+            concatenated_embeddings_token_count=1
+        )) == expected_batch_tokens_list
+
+    def test_should_split_text_and_pad_multiple_tokens(self):
+        batch_text_list = [
+            [
+                ' '.join([WORD_1, WORD_2, WORD_3]),
+                ' '.join([WORD_3, WORD_4])
+            ]
+        ]
+        expected_batch_tokens_list = [
+            [[WORD_1, WORD_3]],
+            [[WORD_2, WORD_4]],
+            [[WORD_3, PAD]]
+        ]
+        assert list(iter_batch_tokens_by_token_index(
+            batch_text_list=batch_text_list,
+            concatenated_embeddings_token_count=3
+        )) == expected_batch_tokens_list
 
 
 class TestGetStatelessWindowIndicesAndOffset:

--- a/tests/sequence_labelling/data_generator_test.py
+++ b/tests/sequence_labelling/data_generator_test.py
@@ -13,6 +13,7 @@ from sciencebeam_trainer_delft.sequence_labelling.data_generator import (
     get_tokens_from_text_features,
     iter_batch_text_list,
     iter_batch_tokens_by_token_index,
+    get_token_padded_batch_text_list,
     get_stateless_window_indices_and_offset,
     get_batch_window_indices_and_offset,
     DataGenerator,
@@ -367,6 +368,25 @@ class TestIterBatchTokensByTokenIndex:
             batch_text_list=batch_text_list,
             concatenated_embeddings_token_count=3
         )) == expected_batch_tokens_list
+
+
+class TestGetTokenPaddedBatchTextList:
+    def test_should_pad_with_longest_token_count(self):
+        batch_text_list = [
+            [
+                ' '.join([WORD_1, WORD_2, WORD_3]),
+                ' '.join([WORD_3, WORD_4])
+            ]
+        ]
+        expected_token_padded_batch_text_list = [
+            [
+                ' '.join([WORD_1, WORD_2, WORD_3]),
+                ' '.join([WORD_3, WORD_4, PAD])
+            ]
+        ]
+        assert get_token_padded_batch_text_list(
+            batch_text_list
+        ) == expected_token_padded_batch_text_list
 
 
 class TestGetStatelessWindowIndicesAndOffset:

--- a/tests/sequence_labelling/data_generator_test.py
+++ b/tests/sequence_labelling/data_generator_test.py
@@ -11,7 +11,6 @@ from delft.sequenceLabelling.preprocess import to_casing_single, PAD
 from sciencebeam_trainer_delft.sequence_labelling.data_generator import (
     left_pad_batch_values,
     get_tokens_from_text_features,
-    get_batch_tokens_from_text_features,
     iter_batch_text_list,
     get_stateless_window_indices_and_offset,
     get_batch_window_indices_and_offset,
@@ -234,24 +233,6 @@ class TestGetTokensFromTextFeatures:
         assert get_tokens_from_text_features([
             'zero', WORD_2, WORD_3
         ], [10]) == []
-
-
-class TestGetBatchTokensFromTextFeatures:
-    def test_should_extract_text_features_and_pad(self):
-        batch_features = [[
-            ['zero', NBSP.join([WORD_1, WORD_2, WORD_3]), WORD_4],
-            ['zero', NBSP.join([WORD_3, WORD_4]), WORD_1]
-        ]]
-        text_feature_indices = [1]
-        expected_batch_tokens = [
-            [[WORD_1, WORD_3]],
-            [[WORD_2, WORD_4]],
-            [[WORD_3, PAD]]
-        ]
-        assert (
-            get_batch_tokens_from_text_features(batch_features, text_feature_indices)
-            == expected_batch_tokens
-        )
 
 
 class TestIterBatchTextList:

--- a/tests/sequence_labelling/data_generator_test.py
+++ b/tests/sequence_labelling/data_generator_test.py
@@ -13,7 +13,6 @@ from sciencebeam_trainer_delft.sequence_labelling.data_generator import (
     get_tokens_from_text_features,
     get_batch_tokens_from_text_features,
     iter_batch_text_list,
-    get_embeddings_tokens_for_concatenation,
     get_stateless_window_indices_and_offset,
     get_batch_window_indices_and_offset,
     DataGenerator,
@@ -325,49 +324,6 @@ class TestIterBatchTextList:
                 text_feature_indices=text_feature_indices
             )) == expected_batch_text_list
         )
-
-
-class TestGetEmbeddingsTokensForConcatenation:
-    def test_should_return_passed_in_tokens(self):
-        all_batch_tokens = [
-            [
-                [WORD_1, WORD_2, WORD_3]
-            ]
-        ]
-        assert get_embeddings_tokens_for_concatenation(
-            all_batch_tokens,
-            concatenated_embeddings_token_count=1
-        ) == all_batch_tokens
-
-    def test_should_truncate_passed_in_tokens(self):
-        all_batch_tokens = [
-            [
-                [WORD_1, WORD_2, WORD_3]
-            ],
-            [
-                [WORD_3, WORD_4, WORD_1]
-            ]
-        ]
-        assert get_embeddings_tokens_for_concatenation(
-            all_batch_tokens,
-            concatenated_embeddings_token_count=1
-        ) == [all_batch_tokens[0]]
-
-    def test_should_append_empty_tokens(self):
-        all_batch_tokens = [
-            [
-                [WORD_1, WORD_2, WORD_3]
-            ]
-        ]
-        expected_batch_tokens = all_batch_tokens + [
-            [
-                [PAD, PAD, PAD]
-            ]
-        ]
-        assert get_embeddings_tokens_for_concatenation(
-            all_batch_tokens,
-            concatenated_embeddings_token_count=2
-        ) == expected_batch_tokens
 
 
 class TestGetStatelessWindowIndicesAndOffset:


### PR DESCRIPTION
part of https://github.com/elifesciences/issues/issues/5896

improvement of #235

This should be more efficient and using less memory.
In the previous version, the chars would have been padded with `<PAD>` for as many times as the maximum number of tokens in the batch. To be able to still load the old model, there is a temporary backward compatibility.
The backward compatibility is enabled, if the model version is below `2`. The model version is a field in the model config (which will be the latest version whenever a new model is trained).