### PR TITLE
added json preprocessor support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ unidecode>=1.0.22
 pydot>=1.2.4
 lmdb>=0.94
 keras-bert>=0.39.0,<0.85.0
+jsonpickle>=1.4.1

--- a/sciencebeam_trainer_delft/utils/io.py
+++ b/sciencebeam_trainer_delft/utils/io.py
@@ -241,6 +241,11 @@ def write_text(filepath: str, text: str, **kwargs):
         fp.write(text)
 
 
+def read_text(filepath: str, **kwargs) -> str:
+    with open_file(filepath, mode='r', **kwargs) as fp:
+        return fp.read()
+
+
 class FileRef(ABC):
     def __init__(self, file_url: str):
         self.file_url = file_url

--- a/sciencebeam_trainer_delft/utils/json.py
+++ b/sciencebeam_trainer_delft/utils/json.py
@@ -1,0 +1,17 @@
+import jsonpickle
+
+
+def to_json(obj, plain_json: bool = False):
+    return jsonpickle.Pickler(
+        unpicklable=not plain_json,
+        keys=True
+    ).flatten(obj)
+
+
+def from_json(json, default_class=None):
+    result = jsonpickle.Unpickler().restore(json)
+    if not isinstance(result, dict) or default_class is None:
+        return result
+    obj = default_class()
+    obj.__setstate__(result)
+    return obj

--- a/tests/sequence_labelling/saving_test.py
+++ b/tests/sequence_labelling/saving_test.py
@@ -204,7 +204,7 @@ class TestModelSaverLoader:
             temp_dir / 'preprocessor_hidden.json'
         )
 
-        loaded_preprocessor = loader.load_preprocessor_from_directory(temp_dir)
+        loaded_preprocessor = loader.load_preprocessor_from_directory(str(temp_dir))
         assert (
             get_normalized_vars_with_type(loaded_preprocessor)
             == get_normalized_vars_with_type(preprocessor)
@@ -218,7 +218,7 @@ class TestModelSaverLoader:
             temp_dir / 'preprocessor_hidden.pickle'
         )
 
-        loaded_preprocessor = loader.load_preprocessor_from_directory(temp_dir)
+        loaded_preprocessor = loader.load_preprocessor_from_directory(str(temp_dir))
         assert (
             get_normalized_vars_with_type(loaded_preprocessor)
             == get_normalized_vars_with_type(preprocessor)
@@ -247,7 +247,7 @@ class TestModelSaverLoader:
             temp_dir / 'preprocessor_hidden.json'
         )
 
-        loaded_preprocessor = loader.load_preprocessor_from_directory(temp_dir)
+        loaded_preprocessor = loader.load_preprocessor_from_directory(str(temp_dir))
         assert (
             get_normalized_vars_with_type(loaded_preprocessor)
             == get_normalized_vars_with_type(preprocessor)
@@ -261,7 +261,7 @@ class TestModelSaverLoader:
             temp_dir / 'preprocessor_hidden.pickle'
         )
 
-        loaded_preprocessor = loader.load_preprocessor_from_directory(temp_dir)
+        loaded_preprocessor = loader.load_preprocessor_from_directory(str(temp_dir))
         assert (
             get_normalized_vars_with_type(loaded_preprocessor)
             == get_normalized_vars_with_type(preprocessor)

--- a/tests/sequence_labelling/saving_test.py
+++ b/tests/sequence_labelling/saving_test.py
@@ -1,0 +1,268 @@
+import json
+import logging
+from pathlib import Path
+
+from delft.sequenceLabelling.preprocess import (
+    WordPreprocessor as DelftWordPreprocessor
+)
+from delft.sequenceLabelling.models import BaseModel
+
+from sciencebeam_trainer_delft.utils.json import to_json, from_json
+
+from sciencebeam_trainer_delft.sequence_labelling.config import ModelConfig
+from sciencebeam_trainer_delft.sequence_labelling.preprocess import (
+    Preprocessor as ScienceBeamPreprocessor,
+    FeaturesPreprocessor,
+    FeaturesIndicesInputPreprocessor
+)
+from sciencebeam_trainer_delft.sequence_labelling.saving import (
+    ModelSaver,
+    ModelLoader
+)
+
+from ..test_utils import log_on_exception
+
+
+LOGGER = logging.getLogger(__name__)
+
+SAMPLE_X = [['Word1']]
+SAMPLE_FEATURES = [[['F1', 'F2']]]
+SAMPLE_Y = [['label1']]
+
+
+class DummyModel(BaseModel):
+    def __init__(self, config, ntags: int = None, data: str = b'dummy data'):
+        super().__init__(config, ntags)
+        self.data = data
+
+    def save(self, filepath):
+        Path(filepath).write_bytes(self.data)
+
+    def load(self, filepath):
+        self.data = Path(filepath).read_bytes()
+
+
+def get_vars(obj) -> dict:
+    try:
+        return obj.__getstate__()
+    except TypeError:
+        try:
+            return vars(obj)
+        except TypeError:
+            attr_map = {
+                attr_name: getattr(obj, attr_name)
+                for attr_name in dir(obj)
+                if not attr_name.startswith('_')
+            }
+            return {
+                key: value
+                for key, value in attr_map.items()
+                if not callable(value)
+            }
+
+
+def get_normalized_vars_with_type(obj) -> dict:
+    variables = get_vars(obj)
+    normalized_vars = {
+        key: (
+            get_normalized_vars_with_type(value)
+            if isinstance(value, FeaturesPreprocessor)
+            else value
+        )
+        for key, value in variables.items()
+        if value is not None
+    }
+    return {
+        'type': type(obj).__qualname__,
+        'vars': normalized_vars
+    }
+
+
+class TestJsonSerializePreprocessors:
+    def test_should_serialize_features_preprocessor(self):
+        features_preprocessor = FeaturesPreprocessor(feature_indices=[0])
+        features_preprocessor.fit(SAMPLE_FEATURES)
+        output_json = json.dumps(to_json(features_preprocessor))
+        LOGGER.debug('original params: %s', features_preprocessor.vectorizer.get_params())
+        LOGGER.debug('original feature_names_: %s', features_preprocessor.vectorizer.feature_names_)
+        LOGGER.debug('original vocabulary_: %s', features_preprocessor.vectorizer.vocabulary_)
+        LOGGER.debug('output_json: %s', output_json)
+        loaded_features_preprocessor = from_json(
+            json.loads(output_json),
+            FeaturesPreprocessor
+        )
+        LOGGER.debug('type: %s', type(loaded_features_preprocessor))
+        assert isinstance(loaded_features_preprocessor, FeaturesPreprocessor)
+        LOGGER.debug('params: %s', loaded_features_preprocessor.vectorizer.get_params())
+        assert (
+            loaded_features_preprocessor.vectorizer.get_params()
+            == features_preprocessor.vectorizer.get_params()
+        )
+        assert (
+            loaded_features_preprocessor.vectorizer.feature_names_
+            == features_preprocessor.vectorizer.feature_names_
+        )
+        assert (
+            loaded_features_preprocessor.vectorizer.vocabulary_
+            == features_preprocessor.vectorizer.vocabulary_
+        )
+
+    def test_should_serialize_features_indices_input_preprocessor(self):
+        features_preprocessor = FeaturesIndicesInputPreprocessor(features_indices=[0])
+        features_preprocessor.fit(SAMPLE_FEATURES)
+        output_json = json.dumps(to_json(features_preprocessor))
+        LOGGER.debug(
+            'original features_vocabulary_size: %s', features_preprocessor.features_vocabulary_size
+        )
+        LOGGER.debug(
+            'original features_indices: %s', features_preprocessor.features_indices
+        )
+        LOGGER.debug(
+            'original features_map_to_index: %s', features_preprocessor.features_map_to_index
+        )
+        LOGGER.debug('output_json: %s', output_json)
+        loaded_features_preprocessor = from_json(
+            json.loads(output_json),
+            FeaturesPreprocessor
+        )
+        LOGGER.debug('type: %s', type(loaded_features_preprocessor))
+        assert isinstance(loaded_features_preprocessor, FeaturesIndicesInputPreprocessor)
+        assert (
+            loaded_features_preprocessor.features_vocabulary_size
+            == features_preprocessor.features_vocabulary_size
+        )
+        assert (
+            loaded_features_preprocessor.features_indices
+            == features_preprocessor.features_indices
+        )
+        assert (
+            loaded_features_preprocessor.features_map_to_index
+            == features_preprocessor.features_map_to_index
+        )
+
+    def test_should_serialize_delft_word_preprocessor(self):
+        preprocessor = DelftWordPreprocessor()
+        preprocessor.fit(SAMPLE_X, SAMPLE_Y)
+        output_json = json.dumps(to_json(preprocessor))
+        LOGGER.debug('original vocab_char: %s', preprocessor.vocab_char)
+        LOGGER.debug('output_json: %s', output_json)
+        loaded_preprocessor = from_json(
+            json.loads(output_json),
+            DelftWordPreprocessor
+        )
+        LOGGER.debug('type: %s', type(loaded_preprocessor))
+        assert isinstance(loaded_preprocessor, DelftWordPreprocessor)
+        LOGGER.debug('loaded vocab_char: %s', loaded_preprocessor.vocab_char)
+        assert (
+            loaded_preprocessor.vocab_char
+            == preprocessor.vocab_char
+        )
+
+    def test_should_serialize_delft_word_preprocessor_to_plain_json(self):
+        preprocessor = DelftWordPreprocessor()
+        preprocessor.fit(SAMPLE_X, SAMPLE_Y)
+        output_json_dict = to_json(preprocessor, plain_json=True)
+        assert output_json_dict.keys() == preprocessor.__dict__.keys()
+        output_json = json.dumps(output_json_dict)
+        LOGGER.debug(
+            'original features_vocabulary_size: %s', preprocessor.vocab_char
+        )
+        LOGGER.debug('output_json: %s', output_json)
+        loaded_preprocessor = from_json(
+            json.loads(output_json),
+            DelftWordPreprocessor
+        )
+        LOGGER.debug('type: %s', type(loaded_preprocessor))
+        assert isinstance(loaded_preprocessor, DelftWordPreprocessor)
+        LOGGER.debug('loaded vocab_char: %s', loaded_preprocessor.vocab_char)
+        assert (
+            loaded_preprocessor.vocab_char
+            == preprocessor.vocab_char
+        )
+        assert (
+            json.dumps(to_json(loaded_preprocessor, plain_json=True))
+            == output_json
+        )
+
+
+class TestModelSaverLoader:
+    @log_on_exception
+    def test_should_save_and_load_delft_preprocessor_from_json_or_pickle(self, temp_dir: Path):
+        model_config = ModelConfig()
+        preprocessor = DelftWordPreprocessor()
+        preprocessor.fit(SAMPLE_X, SAMPLE_Y)
+        model = DummyModel(model_config)
+        saver = ModelSaver(preprocessor=preprocessor, model_config=model_config)
+        loader = ModelLoader()
+
+        saver.save_to(str(temp_dir), model)
+
+        assert (temp_dir / saver.preprocessor_json_file).exists()
+        assert (temp_dir / saver.preprocessor_pickle_file).exists()
+
+        (temp_dir / saver.preprocessor_json_file).rename(
+            temp_dir / 'preprocessor_hidden.json'
+        )
+
+        loaded_preprocessor = loader.load_preprocessor_from_directory(temp_dir)
+        assert (
+            get_normalized_vars_with_type(loaded_preprocessor)
+            == get_normalized_vars_with_type(preprocessor)
+        )
+
+        (temp_dir / 'preprocessor_hidden.json').rename(
+            temp_dir / saver.preprocessor_json_file
+        )
+
+        (temp_dir / saver.preprocessor_pickle_file).rename(
+            temp_dir / 'preprocessor_hidden.pickle'
+        )
+
+        loaded_preprocessor = loader.load_preprocessor_from_directory(temp_dir)
+        assert (
+            get_normalized_vars_with_type(loaded_preprocessor)
+            == get_normalized_vars_with_type(preprocessor)
+        )
+
+    @log_on_exception
+    def test_should_save_and_load_sciencebeam_preprocessor_from_json_or_pickle(
+            self, temp_dir: Path):
+        model_config = ModelConfig()
+        feature_preprocessor = FeaturesPreprocessor([0])
+        preprocessor = ScienceBeamPreprocessor(
+            feature_preprocessor=feature_preprocessor
+        )
+        preprocessor.fit(SAMPLE_X, SAMPLE_Y)
+        preprocessor.fit_features(SAMPLE_X)
+        model = DummyModel(model_config)
+        saver = ModelSaver(preprocessor=preprocessor, model_config=model_config)
+        loader = ModelLoader()
+
+        saver.save_to(str(temp_dir), model)
+
+        assert (temp_dir / saver.preprocessor_json_file).exists()
+        assert (temp_dir / saver.preprocessor_pickle_file).exists()
+
+        (temp_dir / saver.preprocessor_json_file).rename(
+            temp_dir / 'preprocessor_hidden.json'
+        )
+
+        loaded_preprocessor = loader.load_preprocessor_from_directory(temp_dir)
+        assert (
+            get_normalized_vars_with_type(loaded_preprocessor)
+            == get_normalized_vars_with_type(preprocessor)
+        )
+
+        (temp_dir / 'preprocessor_hidden.json').rename(
+            temp_dir / saver.preprocessor_json_file
+        )
+
+        (temp_dir / saver.preprocessor_pickle_file).rename(
+            temp_dir / 'preprocessor_hidden.pickle'
+        )
+
+        loaded_preprocessor = loader.load_preprocessor_from_directory(temp_dir)
+        assert (
+            get_normalized_vars_with_type(loaded_preprocessor)
+            == get_normalized_vars_with_type(preprocessor)
+        )


### PR DESCRIPTION
This more or less reflects the implementation in https://github.com/kermitt2/delft/pull/105

Although with the added complexity that it needs to support different preprocessors and that the `FeaturesPreprocessor` is not JSON serializable out of the box.

It aims to be backward compatible by loading the pickle if the JSON file wasn't found. It will save both JSON and pickle, in case there is an issue with the JSON. It is using `jsonpickle`, i.e. the JSON is not just the plain properties. But it could potentially be converted.

part of https://github.com/elifesciences/issues/issues/5952 to already have the JSON available.