### PR TITLE
added support for original preprocessor pickle

### DIFF
--- a/sciencebeam_trainer_delft/sequence_labelling/preprocess.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/preprocess.py
@@ -113,12 +113,18 @@ class FeaturesPreprocessor(BaseEstimator, TransformerMixin):
         }
 
     def __setstate__(self, state):
-        self.features_indices = state['features_indices']
-        self.pipeline = FeaturesPreprocessor._create_pipeline(
-            feature_indices=self.features_indices
-        )
-        self.vectorizer.feature_names_ = state['vectorizer.feature_names']
-        self.vectorizer.vocabulary_ = state['vectorizer.vocabulary']
+        try:
+            if 'pipeline' in state:
+                # original pickle
+                return super().__setstate__(state)
+            self.features_indices = state['features_indices']
+            self.pipeline = FeaturesPreprocessor._create_pipeline(
+                feature_indices=self.features_indices
+            )
+            self.vectorizer.feature_names_ = state['vectorizer.feature_names']
+            self.vectorizer.vocabulary_ = state['vectorizer.vocabulary']
+        except KeyError as exc:
+            raise KeyError('%r: found %s' % (exc, state.keys()))
         return self
 
     def fit(self, X):


### PR DESCRIPTION
#257 broke loading the original pickle files with the following exception:

```
  File "/opt/sciencebeam-trainer-delft/sciencebeam_trainer_delft/sequence_labelling/preprocess.py", line 120, in __setstate__
    self.vectorizer.feature_names_ = state['vectorizer.feature_names']
KeyError: 'vectorizer.feature_names'
```

This is because the expected state had changed (which is also used for the JSON serialization). This change adds backward compatibility for loading the previously generated pickle files.