### PR TITLE
reduce memory consumption

### DIFF
--- a/sciencebeam_trainer_delft/sequence_labelling/config.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/config.py
@@ -51,7 +51,7 @@ class ModelConfig(_ModelConfig):
 
     @property
     def is_deprecated_padded_batch_text_list_enabled(self):
-        return (
+        return bool(
             self.model_version < 2
             and self.text_feature_indices
         )

--- a/sciencebeam_trainer_delft/sequence_labelling/data_generator.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/data_generator.py
@@ -386,13 +386,16 @@ class DataGenerator(keras.utils.Sequence):
         else:
             self.log_window_config()
         if self.shuffle and self.input_window_stride and stateful:
-            LOGGER.info('not shuffling between epochs as number of batch windows could change')
+            LOGGER.info(
+                'not shuffling between epochs as number of batch windows could change (name=%s)',
+                 self.name
+            )
             self.shuffle = False
         self.is_deprecated_padded_batch_text_list_enabled = (
             is_deprecated_padded_batch_text_list_enabled
         )
         if is_deprecated_padded_batch_text_list_enabled:
-            LOGGER.warning('using deprecated padded batch_text_list')
+            LOGGER.warning('using deprecated padded batch_text_list (name=%s)', self.name)
 
     def get_sample_count(self) -> int:
         if self.window_indices_and_offset:

--- a/sciencebeam_trainer_delft/sequence_labelling/data_generator.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/data_generator.py
@@ -388,7 +388,7 @@ class DataGenerator(keras.utils.Sequence):
         if self.shuffle and self.input_window_stride and stateful:
             LOGGER.info(
                 'not shuffling between epochs as number of batch windows could change (name=%s)',
-                 self.name
+                self.name
             )
             self.shuffle = False
         self.is_deprecated_padded_batch_text_list_enabled = (

--- a/sciencebeam_trainer_delft/sequence_labelling/reader.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/reader.py
@@ -84,7 +84,13 @@ def load_data_and_labels_crf_lines(
         sents.append(tokens)
         labels.append(tags)
         featureSets.append(features)
-    return np.asarray(sents), np.asarray(labels), np.asarray(featureSets)
+    # specifying dtype object can significantly reduce the memory consumption
+    # e.g. for features it could be 20 MB instead of 1 GB
+    return (
+        np.asarray(sents, dtype='object'),
+        np.asarray(labels, dtype='object'),
+        np.asarray(featureSets, dtype='object')
+    )
 
 
 def load_data_crf_lines(

--- a/sciencebeam_trainer_delft/sequence_labelling/tagger.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tagger.py
@@ -7,6 +7,8 @@ import numpy as np
 from delft.utilities.Embeddings import Embeddings
 from delft.utilities.Tokenizer import tokenizeAndFilter
 
+from sciencebeam_trainer_delft.utils.progress_logger import logging_tqdm
+
 from sciencebeam_trainer_delft.sequence_labelling.config import ModelConfig
 from sciencebeam_trainer_delft.sequence_labelling.preprocess import Preprocessor
 from sciencebeam_trainer_delft.sequence_labelling.data_generator import DataGenerator
@@ -91,8 +93,14 @@ def predict_texts_with_sliding_window_if_enabled(
     )
 
     prediction_list_list = [[] for _ in texts]
-    batch_window_indices_and_offsets_iterable = iter_batch_window_indices_and_offsets(
-        predict_generator
+    batch_window_indices_and_offsets_iterable = logging_tqdm(
+        iter_batch_window_indices_and_offsets(
+            predict_generator
+        ),
+        logger=LOGGER,
+        total=len(predict_generator),
+        desc='%s: ' % predict_generator.name,
+        unit='batch'
     )
     for batch_window_indices_and_offsets in batch_window_indices_and_offsets_iterable:
         LOGGER.debug(

--- a/sciencebeam_trainer_delft/sequence_labelling/tagger.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tagger.py
@@ -40,21 +40,27 @@ def predict_texts_with_sliding_window_if_enabled(
         max_actual_sequence_length = max(len(text) for text in texts)
         if max_actual_sequence_length <= max_sequence_length:
             LOGGER.info(
-                'all text sequences below max sequence length: %d <= %d',
-                max_actual_sequence_length, max_sequence_length
+                'all text sequences below max sequence length: %d <= %d (model: %s)',
+                max_actual_sequence_length, max_sequence_length,
+                model_config.model_name
             )
         elif model_config.stateful:
             LOGGER.info(
-                'some text sequences exceed max sequence length (using sliding windows): %d > %d',
-                max_actual_sequence_length, max_sequence_length
+                (
+                    'some text sequences exceed max sequence length (using sliding windows):'
+                    ' %d > %d (model: %s)'
+                ),
+                max_actual_sequence_length, max_sequence_length,
+                model_config.model_name
             )
         else:
             LOGGER.info(
                 (
                     'some text sequences exceed max sequence length'
-                    ' (truncate, model is not stateful): %d > %d'
+                    ' (truncate, model is not stateful): %d > %d (model: %s)'
                 ),
-                max_actual_sequence_length, max_sequence_length
+                max_actual_sequence_length, max_sequence_length,
+                model_config.model_name
             )
 
     predict_generator = DataGenerator(
@@ -81,7 +87,7 @@ def predict_texts_with_sliding_window_if_enabled(
         tokenize=should_tokenize,
         shuffle=False,
         features=features,
-        name='predict_generator'
+        name='%s.predict_generator' % model_config.model_name
     )
 
     prediction_list_list = [[] for _ in texts]

--- a/sciencebeam_trainer_delft/sequence_labelling/trainer.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/trainer.py
@@ -186,7 +186,7 @@ class Trainer(_Trainer):
             ),
             max_sequence_length=self.model_config.max_sequence_length,
             embeddings=self.embeddings,
-            name='%s.%s' % (self.model_config.model_name, name_suffix)
+            name='%s.%s' % (self.model_config.model_name, name_suffix),
             **kwargs
         )
 

--- a/sciencebeam_trainer_delft/sequence_labelling/trainer.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/trainer.py
@@ -168,7 +168,7 @@ class Trainer(_Trainer):
             'training_config': vars(self.training_config)
         }
 
-    def create_data_generator(self, *args, **kwargs) -> DataGenerator:
+    def create_data_generator(self, *args, name_suffix: str, **kwargs) -> DataGenerator:
         return DataGenerator(
             *args,
             batch_size=self.training_config.batch_size,
@@ -186,6 +186,7 @@ class Trainer(_Trainer):
             ),
             max_sequence_length=self.model_config.max_sequence_length,
             embeddings=self.embeddings,
+            name='%s.%s' % (self.model_config.model_name, name_suffix)
             **kwargs
         )
 
@@ -208,14 +209,14 @@ class Trainer(_Trainer):
                 x_train, y_train,
                 shuffle=True,
                 features=features_train,
-                name='training_generator'
+                name_suffix='training_generator'
             )
 
             validation_generator = self.create_data_generator(
                 x_valid, y_valid,
                 shuffle=False,
                 features=features_valid,
-                name='validation_generator'
+                name_suffix='validation_generator'
             )
 
             callbacks = get_callbacks(
@@ -236,7 +237,7 @@ class Trainer(_Trainer):
                 x_train, y_train,
                 shuffle=True,
                 features=features_all,
-                name='training_generator'
+                name_suffix='training_generator'
             )
 
             callbacks = get_callbacks(

--- a/sciencebeam_trainer_delft/sequence_labelling/wrapper.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/wrapper.py
@@ -369,7 +369,7 @@ class Sequence(_Sequence):
             x_test, y_test,
             features=features,
             shuffle=False,
-            name='test_generator'
+            name='%s.test_generator' % self.model_config.model_name
         )
 
         prediction_result = get_model_results(

--- a/sciencebeam_trainer_delft/utils/progress_logger.py
+++ b/sciencebeam_trainer_delft/utils/progress_logger.py
@@ -1,0 +1,39 @@
+import logging
+
+from tqdm import tqdm
+
+
+LOGGER = logging.getLogger()
+
+
+class logging_tqdm(tqdm):
+    def __init__(
+            self,
+            *args,
+            logger: logging.Logger = None,
+            mininterval: float = 1,
+            bar_format: str = '{desc}{percentage:3.0f}%{r_bar}',
+            desc: str = 'progress: ',
+            **kwargs):
+        self._logger = logger
+        super().__init__(
+            *args,
+            mininterval=mininterval,
+            bar_format=bar_format,
+            desc=desc,
+            **kwargs
+        )
+
+    @property
+    def logger(self):
+        if self._logger is not None:
+            return self._logger
+        return LOGGER
+
+    def display(self, msg=None, pos=None):
+        if not self.n:
+            # skip progress bar before having processed anything
+            return
+        if not msg:
+            msg = self.__repr__()
+        self.logger.info('%s', msg)


### PR DESCRIPTION
part of https://github.com/elifesciences/issues/issues/6057

One of the main contributors was `np.asarray` without a `dtype`, which may have resulted in 1 GB instead of 20 MB for the features array, which consists of many small strings (often just one character).