### PR TITLE
fixed tagging fails with empty input

### DIFF
--- a/sciencebeam_trainer_delft/sequence_labelling/tagger.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tagger.py
@@ -34,6 +34,9 @@ def predict_texts_with_sliding_window_if_enabled(
         input_window_stride: int = None,
         embeddings: Embeddings = None,
         features: List[List[List[str]]] = None):
+    if not texts:
+        LOGGER.info('passed in empty texts, model: %s', model_config.model_name)
+        return []
     should_tokenize = (
         len(texts) > 0  # pylint: disable=len-as-condition
         and isinstance(texts[0], str)

--- a/tests/sequence_labelling/tagger_test.py
+++ b/tests/sequence_labelling/tagger_test.py
@@ -41,7 +41,7 @@ def _model_mock():
 
 @pytest.fixture(name='model_config')
 def _model_config():
-    return ModelConfig(batch_size=1)
+    return ModelConfig(model_name='test_model', batch_size=1)
 
 
 def get_preprocessor(
@@ -122,6 +122,27 @@ def get_predict_on_batch_by_token_fn(
 
 
 class TestTagger:
+    def test_should_return_empty_result_for_empty_input(
+            self,
+            model_mock: MagicMock,
+            model_config: ModelConfig,
+            preprocessor: WordPreprocessor):
+        tagger = Tagger(
+            model=model_mock,
+            model_config=model_config,
+            preprocessor=preprocessor,
+            max_sequence_length=2,
+            input_window_stride=None
+        )
+        model_mock.predict_on_batch.side_effect = get_predict_on_batch_by_token_fn(
+            DEFAULT_TAG_BY_TOKEN_MAP,
+            preprocessor=preprocessor,
+            batch_size=model_config.batch_size
+        )
+        tag_result = tagger.tag([], output_format=None)
+        LOGGER.debug('tag_result: %s', tag_result)
+        assert tag_result == []
+
     def test_should_truncate_without_input_window_stride(
             self,
             model_mock: MagicMock,


### PR DESCRIPTION
GROBID might pass an empty input to the model. That caused the tagging to throw an exception.
This PR will at least fix it on the Python side and respond with an empty response.