### PR TITLE
fixed feature indices not passed on

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,8 +178,8 @@ test: \
 		--word-lstm-units="$(WORD_LSTM_UNITS)" \
 		--embedding="$(EMBEDDING)" \
 		--architecture="$(ARCHITECTURE)" \
-		--feature-indices="$(FEATURE_INDICES)" \
-		--feature-embedding-size="$(FEATURE_EMBEDDING_SIZE)" \
+		--features-indices="$(FEATURE_INDICES)" \
+		--features-embedding-size="$(FEATURE_EMBEDDING_SIZE)" \
 		--max-epoch="$(MAX_EPOCH)" \
 		--model-path="$(MODEL_PATH)" \
 		--output="$(MODEL_OUTPUT)" \

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ The model needs to support using such features. The following models do:
 - `CustomBidLSTM_CRF`
 - `CustomBidLSTM_CRF_FEATURES`
 
-The features are generally provided. Some of the features are not suitable as input features because there are too many of them (e.g. a variation of the token itself). The features should be specified via `--feature-indices`. The `input_info` sub command can help identify useful feature ranges (based on the count of unique values).
+The features are generally provided. Some of the features are not suitable as input features because there are too many of them (e.g. a variation of the token itself). The features should be specified via `--features-indices`. The `input_info` sub command can help identify useful feature ranges (based on the count of unique values).
 
 Example commands:
 
@@ -220,8 +220,8 @@ python -m sciencebeam_trainer_delft.sequence_labelling.grobid_trainer \
     --limit="100" \
     --architecture="BidLSTM_CRF_FEATURES" \
     --use-features \
-    --feature-indices="9-30" \
-    --feature-embedding-size="5" \
+    --features-indices="9-30" \
+    --features-embedding-size="5" \
     --features-lstm-units="7" \
     --early-stopping-patience="10" \
     --max-epoch="50"
@@ -239,8 +239,8 @@ python -m sciencebeam_trainer_delft.sequence_labelling.grobid_trainer \
     --limit="100" \
     --architecture="CustomBidLSTM_CRF_FEATURES" \
     --use-features \
-    --feature-indices="9-30" \
-    --feature-embedding-size="5" \
+    --features-indices="9-30" \
+    --features-embedding-size="5" \
     --features-lstm-units="7" \
     --early-stopping-patience="10" \
     --max-epoch="50"
@@ -258,8 +258,8 @@ python -m sciencebeam_trainer_delft.sequence_labelling.grobid_trainer \
     --limit="100" \
     --architecture="CustomBidLSTM_CRF" \
     --use-features \
-    --feature-indices="9-30" \
-    --feature-embedding-size="0" \
+    --features-indices="9-30" \
+    --features-embedding-size="0" \
     --features-lstm-units="0" \
     --early-stopping-patience="10" \
     --max-epoch="50"

--- a/notebooks/train-header.ipynb
+++ b/notebooks/train-header.ipynb
@@ -92,7 +92,7 @@
     "    '--batch-size=5',\n",
     "    '--max-epoch=1',\n",
     "    '--use-features',\n",
-    "    '--feature-indices=9-30',\n",
+    "    '--features-indices=9-30',\n",
     "    '--architecture=CustomBidLSTM_CRF',\n",
     "    '--input=https://github.com/kermitt2/delft/raw/master/data/sequenceLabelling/grobid/header/header-060518.train',\n",
     "    '--embedding=https://github.com/elifesciences/sciencebeam-models/releases/download/v0.0.1/glove.6B.50d.txt.xz'\n",

--- a/sciencebeam_trainer_delft/sequence_labelling/config.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/config.py
@@ -15,8 +15,6 @@ NOT_SET = -1
 
 
 class ModelConfig(_ModelConfig):
-    DEFAULT_FEATURES_VOCABULARY_SIZE = 12
-
     def __init__(
             self,
             *args,
@@ -26,7 +24,6 @@ class ModelConfig(_ModelConfig):
             additional_token_feature_indices: List[int] = None,
             text_feature_indices: List[int] = None,
             concatenated_embeddings_token_count: int = None,
-            features_vocabulary_size: int = DEFAULT_FEATURES_VOCABULARY_SIZE,
             features_lstm_units: int = None,
             use_features_indices_input: bool = False,
             stateful: bool = False,
@@ -46,7 +43,6 @@ class ModelConfig(_ModelConfig):
         self.concatenated_embeddings_token_count = concatenated_embeddings_token_count
         self.use_features = use_features
         self.max_feature_size = max_feature_size
-        self.features_vocabulary_size = features_vocabulary_size
         self.features_lstm_units = features_lstm_units
         self.use_features_indices_input = use_features_indices_input
         self.stateful = stateful

--- a/sciencebeam_trainer_delft/sequence_labelling/config.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/config.py
@@ -11,6 +11,9 @@ FIRST_MODEL_VERSION = 1
 MODEL_VERSION = 2
 
 
+NOT_SET = -1
+
+
 class ModelConfig(_ModelConfig):
     DEFAULT_FEATURES_VOCABULARY_SIZE = 12
     DEFAULT_FEATURES_EMBEDDING_SIZE = 4
@@ -24,14 +27,19 @@ class ModelConfig(_ModelConfig):
             additional_token_feature_indices: List[int] = None,
             text_feature_indices: List[int] = None,
             concatenated_embeddings_token_count: int = None,
-            feature_indices: List[int] = None,
-            feature_embedding_size: int = DEFAULT_FEATURES_EMBEDDING_SIZE,
             features_vocabulary_size: int = DEFAULT_FEATURES_VOCABULARY_SIZE,
             features_lstm_units: int = None,
             use_features_indices_input: bool = False,
             stateful: bool = False,
             model_version: int = MODEL_VERSION,
+            # deprecated
+            feature_indices: List[int] = None,
+            feature_embedding_size: int = NOT_SET,
             **kwargs):
+        if feature_indices:
+            kwargs['features_indices'] = feature_indices
+        if feature_embedding_size != NOT_SET:
+            kwargs['features_embedding_size'] = feature_embedding_size
         super().__init__(*args)
         self.use_word_embeddings = use_word_embeddings
         self.additional_token_feature_indices = additional_token_feature_indices
@@ -39,8 +47,6 @@ class ModelConfig(_ModelConfig):
         self.concatenated_embeddings_token_count = concatenated_embeddings_token_count
         self.use_features = use_features
         self.max_feature_size = max_feature_size
-        self.feature_indices = feature_indices
-        self.feature_embedding_size = feature_embedding_size
         self.features_vocabulary_size = features_vocabulary_size
         self.features_lstm_units = features_lstm_units
         self.use_features_indices_input = use_features_indices_input
@@ -74,20 +80,26 @@ class ModelConfig(_ModelConfig):
 
     # alias due to properties having been renamed in upstream implementation
     @property
-    def features_indices(self):
-        return self.feature_indices
+    def feature_indices(self) -> List[int]:
+        return (
+            self.features_indices
+            or self.__dict__.get('feature_indices')
+        )
 
-    @features_indices.setter
-    def features_indices(self, feature_indices: List[int]):
-        self.feature_indices = feature_indices
+    @feature_indices.setter
+    def feature_indices(self, feature_indices: List[int]):
+        self.features_indices = feature_indices
 
     @property
-    def features_embedding_size(self):
-        return self.feature_embedding_size
+    def feature_embedding_size(self):
+        return (
+            self.features_embedding_size
+            or self.__dict__.get('feature_embedding_size')
+        )
 
-    @features_embedding_size.setter
-    def features_embedding_size(self, feature_embedding_size: List[int]):
-        self.feature_embedding_size = feature_embedding_size
+    @feature_embedding_size.setter
+    def feature_embedding_size(self, feature_embedding_size: List[int]):
+        self.features_embedding_size = feature_embedding_size
 
 
 class TrainingConfig(_TrainingConfig):

--- a/sciencebeam_trainer_delft/sequence_labelling/config.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/config.py
@@ -24,7 +24,6 @@ class ModelConfig(_ModelConfig):
             additional_token_feature_indices: List[int] = None,
             text_feature_indices: List[int] = None,
             concatenated_embeddings_token_count: int = None,
-            features_lstm_units: int = None,
             use_features_indices_input: bool = False,
             stateful: bool = False,
             model_version: int = MODEL_VERSION,
@@ -43,7 +42,6 @@ class ModelConfig(_ModelConfig):
         self.concatenated_embeddings_token_count = concatenated_embeddings_token_count
         self.use_features = use_features
         self.max_feature_size = max_feature_size
-        self.features_lstm_units = features_lstm_units
         self.use_features_indices_input = use_features_indices_input
         self.stateful = stateful
         self.model_version = model_version

--- a/sciencebeam_trainer_delft/sequence_labelling/config.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/config.py
@@ -16,7 +16,6 @@ NOT_SET = -1
 
 class ModelConfig(_ModelConfig):
     DEFAULT_FEATURES_VOCABULARY_SIZE = 12
-    DEFAULT_FEATURES_EMBEDDING_SIZE = 4
 
     def __init__(
             self,

--- a/sciencebeam_trainer_delft/sequence_labelling/grobid_trainer.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/grobid_trainer.py
@@ -1415,8 +1415,8 @@ class GrobidTrainerSubCommand(SubCommand):
             recurrent_dropout=args.recurrent_dropout,
             max_epoch=args.max_epoch,
             use_features=args.use_features,
-            feature_indices=args.feature_indices,
-            feature_embedding_size=args.feature_embedding_size,
+            features_indices=args.feature_indices,
+            features_embedding_size=args.feature_embedding_size,
             patience=args.early_stopping_patience,
             config_props=dict(
                 max_char_length=args.max_char_length,

--- a/sciencebeam_trainer_delft/sequence_labelling/grobid_trainer.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/grobid_trainer.py
@@ -1192,12 +1192,13 @@ def add_train_arguments(parser: argparse.ArgumentParser):
     features_group = parser.add_argument_group('features')
     features_group.add_argument("--use-features", action="store_true", help="Use features")
     features_group.add_argument(
-        "--feature-indices",
+        "--features-indices", "--feature-indices",
         type=parse_number_ranges,
         help="The feature indices to use. e.g. 7-10. If blank, all of the features will be used."
     )
     features_group.add_argument(
-        "--feature-embedding-size", type=int,
+        "--features-embedding-size", "--feature-embedding-size",
+        type=int,
         help="size of feature embedding, use 0 to disable embedding"
     )
     features_group.add_argument(
@@ -1415,8 +1416,8 @@ class GrobidTrainerSubCommand(SubCommand):
             recurrent_dropout=args.recurrent_dropout,
             max_epoch=args.max_epoch,
             use_features=args.use_features,
-            features_indices=args.feature_indices,
-            features_embedding_size=args.feature_embedding_size,
+            features_indices=args.features_indices,
+            features_embedding_size=args.features_embedding_size,
             patience=args.early_stopping_patience,
             config_props=dict(
                 max_char_length=args.max_char_length,

--- a/sciencebeam_trainer_delft/sequence_labelling/models.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/models.py
@@ -117,11 +117,11 @@ class CustomBidLSTM_CRF(CustomModel):
             )
             model_inputs.append(features_input)
             features = features_input
-            if config.feature_embedding_size:
+            if config.features_embedding_size:
                 features = TimeDistributed(Dense(
-                    config.feature_embedding_size,
-                    name='feature_embeddings_dense'
-                ), name='feature_embeddings')(features)
+                    config.features_embedding_size,
+                    name='features_embeddings_dense'
+                ), name='features_embeddings')(features)
             LOGGER.info(
                 'word_input=%s, charts=%s, features=%s',
                 word_input, chars, features

--- a/sciencebeam_trainer_delft/sequence_labelling/preprocess.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/preprocess.py
@@ -19,6 +19,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 def to_dict(value_list_batch: List[list], feature_indices: Set[int] = None):
+    # Note: keeping `feature_indices` name for pickle compatibility
+    #   (also matches upstream for `to_dict`)
     return [
         {
             index: value
@@ -35,19 +37,19 @@ class WordPreprocessor(DelftWordPreprocessor):
 
 
 class FeaturesPreprocessor(BaseEstimator, TransformerMixin):
-    def __init__(self, feature_indices: Iterable[int] = None):
-        self.features_indices = feature_indices
+    def __init__(self, features_indices: Iterable[int] = None):
+        self.features_indices = features_indices
         self.features_map_to_index = None
         self.pipeline = FeaturesPreprocessor._create_pipeline(
-            feature_indices=feature_indices
+            features_indices=features_indices
         )
 
     @staticmethod
-    def _create_pipeline(feature_indices: Iterable[int] = None):
-        feature_indices_set = None
-        if feature_indices:
-            feature_indices_set = set(feature_indices)
-        to_dict_fn = partial(to_dict, feature_indices=feature_indices_set)
+    def _create_pipeline(features_indices: Iterable[int] = None):
+        features_indices_set = None
+        if features_indices:
+            features_indices_set = set(features_indices)
+        to_dict_fn = partial(to_dict, feature_indices=features_indices_set)
         return Pipeline(steps=[
             ('to_dict', FunctionTransformer(to_dict_fn, validate=False)),
             ('vectorize', DictVectorizer(sparse=False))
@@ -71,7 +73,7 @@ class FeaturesPreprocessor(BaseEstimator, TransformerMixin):
                 return super().__setstate__(state)
             self.features_indices = state['features_indices']
             self.pipeline = FeaturesPreprocessor._create_pipeline(
-                feature_indices=self.features_indices
+                features_indices=self.features_indices
             )
             self.vectorizer.feature_names_ = state['vectorizer.feature_names']
             self.vectorizer.vocabulary_ = state['vectorizer.vocabulary']

--- a/sciencebeam_trainer_delft/sequence_labelling/wrapper.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/wrapper.py
@@ -116,7 +116,7 @@ def get_features_preprocessor(
         'using feature indices=%s', model_config.features_indices
     )
     return ScienceBeamFeaturesPreprocessor(
-        feature_indices=model_config.feature_indices
+        features_indices=model_config.features_indices
     )
 
 
@@ -158,8 +158,8 @@ class Sequence(_Sequence):
     def __init__(
             self, *args,
             use_features: bool = False,
-            feature_indices: List[int] = None,
-            feature_embedding_size: int = None,
+            features_indices: List[int] = None,
+            features_embedding_size: int = None,
             multiprocessing: bool = False,
             embedding_registry_path: str = None,
             embedding_manager: EmbeddingManager = None,
@@ -211,11 +211,11 @@ class Sequence(_Sequence):
         self.model_config = ModelConfig(
             **{
                 **vars(self.model_config),
-                **(config_props or {})
+                **(config_props or {}),
+                'features_indices': features_indices,
+                'features_embedding_size': features_embedding_size
             },
-            use_features=use_features,
-            feature_indices=feature_indices,
-            feature_embedding_size=feature_embedding_size
+            use_features=use_features
         )
         self.update_model_config_word_embedding_size()
         updated_implicit_model_config_props(self.model_config)

--- a/sciencebeam_trainer_delft/sequence_labelling/wrapper.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/wrapper.py
@@ -97,13 +97,24 @@ def get_default_stateful() -> bool:
 def get_features_preprocessor(
         model_config: ModelConfig,
         features: np.array = None) -> T_FeaturesPreprocessor:
-    if not model_config.use_features or features is None:
+    if not model_config.use_features:
+        LOGGER.info('features not enabled')
+        return None
+    if features is None:
+        LOGGER.info('no features available')
         return None
     if model_config.use_features_indices_input:
+        LOGGER.info(
+            'using feature indices as input, features_indices=%s, features_vocab_size=%s',
+            model_config.features_indices, model_config.features_vocabulary_size
+        )
         return FeaturesPreprocessor(
             features_indices=model_config.features_indices,
             features_vocabulary_size=model_config.features_vocabulary_size
         )
+    LOGGER.info(
+        'using feature indices=%s', model_config.features_indices
+    )
     return ScienceBeamFeaturesPreprocessor(
         feature_indices=model_config.feature_indices
     )

--- a/tests/sequence_labelling/config_test.py
+++ b/tests/sequence_labelling/config_test.py
@@ -1,0 +1,28 @@
+from sciencebeam_trainer_delft.sequence_labelling.config import ModelConfig
+
+
+FEATURE_INDICES_1 = [9, 10, 11]
+
+FEATURES_EMBEDDING_SIZE_1 = 13
+
+
+class TestModelConfig:
+    def test_should_be_able_to_pass_in_feature_indices(self):
+        model_config = ModelConfig(feature_indices=FEATURE_INDICES_1)
+        assert model_config.feature_indices == FEATURE_INDICES_1
+        assert model_config.features_indices == FEATURE_INDICES_1
+
+    def test_should_be_able_to_pass_in_features_indices(self):
+        model_config = ModelConfig(features_indices=FEATURE_INDICES_1)
+        assert model_config.feature_indices == FEATURE_INDICES_1
+        assert model_config.features_indices == FEATURE_INDICES_1
+
+    def test_should_be_able_to_pass_in_feature_embedding_size(self):
+        model_config = ModelConfig(feature_embedding_size=FEATURES_EMBEDDING_SIZE_1)
+        assert model_config.feature_embedding_size == FEATURES_EMBEDDING_SIZE_1
+        assert model_config.features_embedding_size == FEATURES_EMBEDDING_SIZE_1
+
+    def test_should_be_able_to_pass_in_features_embedding_size(self):
+        model_config = ModelConfig(features_embedding_size=FEATURES_EMBEDDING_SIZE_1)
+        assert model_config.feature_embedding_size == FEATURES_EMBEDDING_SIZE_1
+        assert model_config.features_embedding_size == FEATURES_EMBEDDING_SIZE_1

--- a/tests/sequence_labelling/grobid_trainer_test.py
+++ b/tests/sequence_labelling/grobid_trainer_test.py
@@ -159,7 +159,7 @@ def _default_args(
         output_path=str(model_base_path),
         architecture='CustomBidLSTM_CRF',
         word_lstm_units=11,
-        feature_indices=list(range(7, 1 + 10)),
+        features_indices=list(range(7, 1 + 10)),
         embedding_registry_path=str(embedding_registry_path)
     )
 
@@ -381,8 +381,8 @@ class TestGrobidTrainer:
                 use_features=True,
                 **{
                     **default_args,
-                    'feature_indices': FEATURE_INDICES_1,
-                    'feature_embedding_size': None
+                    'features_indices': FEATURE_INDICES_1,
+                    'features_embedding_size': None
                 }
             )
             model_config = load_model_config(default_model_directory)
@@ -404,8 +404,8 @@ class TestGrobidTrainer:
                 use_features=True,
                 **{
                     **default_args,
-                    'feature_indices': FEATURE_INDICES_1,
-                    'feature_embedding_size': FEATURES_EMBEDDING_SIZE_1
+                    'features_indices': FEATURE_INDICES_1,
+                    'features_embedding_size': FEATURES_EMBEDDING_SIZE_1
                 }
             )
             model_config = load_model_config(default_model_directory)
@@ -499,7 +499,7 @@ class TestGrobidTrainer:
             train_args = {
                 **default_args,
                 'architecture': 'BidLSTM_CRF_FEATURES',
-                'feature_embedding_size': 4,
+                'features_embedding_size': 4,
                 'config_props': {
                     'features_lstm_units': 4
                 }
@@ -525,7 +525,7 @@ class TestGrobidTrainer:
             train_args = {
                 **default_args,
                 'architecture': 'CustomBidLSTM_CRF_FEATURES',
-                'feature_embedding_size': 4,
+                'features_embedding_size': 4,
                 'config_props': {
                     'features_lstm_units': 4
                 }

--- a/tests/sequence_labelling/grobid_trainer_test.py
+++ b/tests/sequence_labelling/grobid_trainer_test.py
@@ -364,6 +364,8 @@ class TestGrobidTrainer:
                 use_features=False,
                 **default_args
             )
+            model_config = load_model_config(default_model_directory)
+            assert not model_config.use_features
             tag_input(
                 model=default_args['model'],
                 model_path=default_model_directory,
@@ -431,6 +433,8 @@ class TestGrobidTrainer:
                     }
                 }
             )
+            model_config = load_model_config(default_model_directory)
+            assert model_config.embeddings_name is None
             tag_input(
                 model=default_args['model'],
                 model_path=default_model_directory,
@@ -452,6 +456,9 @@ class TestGrobidTrainer:
                     }
                 }
             )
+            model_config = load_model_config(default_model_directory)
+            assert model_config.max_char_length == 60
+            assert model_config.additional_token_feature_indices == [0]
             tag_input(
                 model=default_args['model'],
                 model_path=default_model_directory,
@@ -474,6 +481,10 @@ class TestGrobidTrainer:
                     }
                 }
             )
+            model_config = load_model_config(default_model_directory)
+            assert model_config.max_char_length == 60
+            assert model_config.text_feature_indices == [0]
+            assert model_config.concatenated_embeddings_token_count == 2
             tag_input(
                 model=default_args['model'],
                 model_path=default_model_directory,
@@ -496,6 +507,10 @@ class TestGrobidTrainer:
             train(
                 **train_args
             )
+            model_config = load_model_config(default_model_directory)
+            assert model_config.model_type == 'BidLSTM_CRF_FEATURES'
+            assert model_config.features_embedding_size == 4
+            assert model_config.features_lstm_units == 4
             tag_input(
                 model=default_args['model'],
                 model_path=default_model_directory,
@@ -518,6 +533,10 @@ class TestGrobidTrainer:
             train(
                 **train_args
             )
+            model_config = load_model_config(default_model_directory)
+            assert model_config.model_type == 'CustomBidLSTM_CRF_FEATURES'
+            assert model_config.features_embedding_size == 4
+            assert model_config.features_lstm_units == 4
             tag_input(
                 model=default_args['model'],
                 model_path=default_model_directory,

--- a/tests/sequence_labelling/models_test.py
+++ b/tests/sequence_labelling/models_test.py
@@ -46,12 +46,12 @@ class TestCustomBidLSTM_CRF:
 
     def test_should_be_able_to_build_with_feature_embedding(self, model_config: ModelConfig):
         model_config.use_features = True
-        model_config.feature_embedding_size = 11
+        model_config.features_embedding_size = 11
         CustomBidLSTM_CRF(model_config, ntags=5)
 
     def test_should_be_able_to_build_stateful_lstms(self, model_config: ModelConfig):
         model_config.use_features = True
-        model_config.feature_embedding_size = 11
+        model_config.features_embedding_size = 11
         model_config.stateful = True
         CustomBidLSTM_CRF(model_config, ntags=5)
 

--- a/tests/sequence_labelling/preprocess_test.py
+++ b/tests/sequence_labelling/preprocess_test.py
@@ -116,7 +116,7 @@ class TestFeaturesPreprocessor:
         assert all_close(features_transformed, [[[0]]])
 
     def test_should_select_features(self):
-        preprocessor = FeaturesPreprocessor(feature_indices=[1])
+        preprocessor = FeaturesPreprocessor(features_indices=[1])
         features_batch = [[
             [FEATURE_VALUE_1, FEATURE_VALUE_2],
             [FEATURE_VALUE_1, FEATURE_VALUE_3],

--- a/tests/sequence_labelling/saving_test.py
+++ b/tests/sequence_labelling/saving_test.py
@@ -80,7 +80,7 @@ def get_normalized_vars_with_type(obj) -> dict:
 
 class TestJsonSerializePreprocessors:
     def test_should_serialize_features_preprocessor(self):
-        features_preprocessor = ScienceBeamFeaturesPreprocessor(feature_indices=[0])
+        features_preprocessor = ScienceBeamFeaturesPreprocessor(features_indices=[0])
         features_preprocessor.fit(SAMPLE_FEATURES)
         preprocessor = DelftWordPreprocessor(feature_preprocessor=features_preprocessor)
         LOGGER.debug('original params: %s', features_preprocessor.vectorizer.get_params())


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/73

The arguments `--feature-indices` and `--feature-embedding-size` were not properly passed in. That is because some of the code was adopted upstream but with a slightly different name (`features` instead of `feature`). In attempting to make it compatible, this wasn't properly passed in. The tests didn't catch that.

This PR fixes that, it also changes most reference to the name used upstream to avoid confusion. It should still be backwards compatible with previous models.