### PR TITLE
configure Jenkins to run builds in parallel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,29 +26,18 @@ elifePipeline {
                     withCommitStatus({
                         sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-build-core"
                     }, 'ci-build-core', commit)
-                    def subActions = [
-                        'ci-lint': {
-                            withCommitStatus({
-                                sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-lint"
-                            }, 'ci-lint', commit)
-                        },
-                        'ci-pytest-not-slow': {
-                            withCommitStatus({
-                                sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-pytest-not-slow"
-                            }, 'ci-pytest-not-slow', commit)
-                        },
-                        'ci-pytest-slow': {
-                            withCommitStatus({
-                                sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-pytest-slow"
-                            }, 'ci-pytest-slow', commit)
-                        },
-                        'ci-test-setup-install': {
-                            withCommitStatus({
-                                sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-test-setup-install"
-                            }, 'ci-test-setup-install', commit)
-                        }
-                    ]
-                    parallel subActions
+                    withCommitStatus({
+                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-lint"
+                    }, 'ci-lint', commit)
+                    withCommitStatus({
+                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-pytest-not-slow"
+                    }, 'ci-pytest-not-slow', commit)
+                    withCommitStatus({
+                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-pytest-slow"
+                    }, 'ci-pytest-slow', commit)
+                    withCommitStatus({
+                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-test-setup-install"
+                    }, 'ci-test-setup-install', commit)
                 },
                 'ci-build-grobid': {
                     withCommitStatus({

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,8 +24,31 @@ elifePipeline {
             def actions = [
                 'ci-build-and-test-core': {
                     withCommitStatus({
-                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-build-and-test-core"
-                    }, 'ci-build-and-test-core', commit)
+                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-build-core"
+                    }, 'ci-build-core', commit)
+                    def subActions = [
+                        'ci-lint': {
+                            withCommitStatus({
+                                sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-lint"
+                            }, 'ci-lint', commit)
+                        },
+                        'ci-pytest-not-slow': {
+                            withCommitStatus({
+                                sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-pytest-not-slow"
+                            }, 'ci-pytest-not-slow', commit)
+                        },
+                        'ci-pytest-slow': {
+                            withCommitStatus({
+                                sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-pytest-slow"
+                            }, 'ci-pytest-slow', commit)
+                        },
+                        'ci-test-setup-install': {
+                            withCommitStatus({
+                                sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-test-setup-install"
+                            }, 'ci-test-setup-install', commit)
+                        }
+                    ]
+                    parallel subActions
                 },
                 'ci-build-grobid': {
                     withCommitStatus({

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,17 +25,17 @@ elifePipeline {
                 'ci-build-and-test-core': {
                     withCommitStatus({
                         sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-build-and-test-core"
-                    }, 'build and test core', commit)
+                    }, 'ci-build-and-test-core', commit)
                 },
                 'ci-build-grobid': {
                     withCommitStatus({
                         sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-build-grobid"
-                    }, 'build grobid', commit)
+                    }, 'ci-build-grobid', commit)
                 },
                 'ci-build-grobid-trainer': {
                     withCommitStatus({
                         sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-build-grobid-trainer"
-                    }, 'build and test core', commit)
+                    }, 'ci-build-grobid-trainer', commit)
                 },
                 'ci-build-and-test-jupyter': {
                     withCommitStatus({

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,8 +21,30 @@ elifePipeline {
         }
 
         stage 'Build and run tests', {
+            def actions = [
+                'ci-build-and-test-core': {
+                    withCommitStatus({
+                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-build-and-test-core"
+                    }, 'build and test core', commit)
+                },
+                'ci-build-grobid': {
+                    withCommitStatus({
+                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-build-grobid"
+                    }, 'build grobid', commit)
+                },
+                'ci-build-grobid-trainer': {
+                    withCommitStatus({
+                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-build-grobid-trainer"
+                    }, 'build and test core', commit)
+                },
+                'ci-build-and-test-jupyter': {
+                    withCommitStatus({
+                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-build-and-test-jupyter"
+                    }, 'ci-build-and-test-jupyter', commit)
+                }
+            ]
             try {
-                sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-build-and-test"
+                parallel actions
             } finally {
                 sh "make ci-clean"
             }

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ GCLOUD_ARGS =
 PYTEST_ARGS =
 NOT_SLOW_PYTEST_ARGS = -m 'not slow'
 
+SYSTEM_PYTHON = python3
+
 ARGS =
 
 
@@ -66,7 +68,7 @@ venv-clean:
 
 
 venv-create:
-	python3 -m venv $(VENV)
+	$(SYSTEM_PYTHON) -m venv $(VENV)
 
 
 dev-install:
@@ -343,6 +345,22 @@ jupyter-stop:
 ci-build-and-test:
 	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" \
 		build test grobid-build trainer-grobid-build jupyter-build update-test-notebook-temp
+
+
+ci-build-and-test-core:
+	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" build test
+
+
+ci-build-grobid:
+	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" grobid-build
+
+
+ci-build-grobid-trainer:
+	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" trainer-grobid-build
+
+
+ci-build-and-test-jupyter:
+	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" jupyter-build update-test-notebook-temp
 
 
 ci-clean:

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ GCLOUD_ARGS =
 
 PYTEST_ARGS =
 NOT_SLOW_PYTEST_ARGS = -m 'not slow'
+SLOW_PYTEST_ARGS = -m 'slow'
 
 SYSTEM_PYTHON = python3
 
@@ -136,6 +137,10 @@ pytest:
 
 pytest-not-slow:
 	@$(MAKE) PYTEST_ARGS="$(PYTEST_ARGS) $(NOT_SLOW_PYTEST_ARGS)" pytest
+
+
+pytest-slow:
+	@$(MAKE) PYTEST_ARGS="$(PYTEST_ARGS) $(SLOW_PYTEST_ARGS)" pytest
 
 
 .watch:
@@ -349,6 +354,26 @@ ci-build-and-test:
 
 ci-build-and-test-core:
 	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" build test
+
+
+ci-build-core:
+	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" build
+
+
+ci-lint:
+	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" lint
+
+
+ci-pytest-not-slow:
+	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" pytest-not-slow
+
+
+ci-pytest-slow:
+	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" pytest-slow
+
+
+ci-test-setup-install:
+	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" test-setup-install
 
 
 ci-build-grobid:


### PR DESCRIPTION
The Jenkins build is currently quite slow.
This is an attempt to speed things up by running some independent builds in parallel.