### PR TITLE
added --checkpoint-epoch-interval

### DIFF
--- a/sciencebeam_trainer_delft/sequence_labelling/config.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/config.py
@@ -101,7 +101,9 @@ class TrainingConfig(_TrainingConfig):
             *args,
             initial_epoch: int = None,
             input_window_stride: int = None,
+            checkpoint_epoch_interval: int = 1,
             **kwargs):
         super().__init__(*args, **kwargs)
         self.initial_epoch = initial_epoch
         self.input_window_stride = input_window_stride
+        self.checkpoint_epoch_interval = checkpoint_epoch_interval

--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli.py
@@ -185,7 +185,8 @@ class GrobidTrainerSubCommand(SubCommand):
             ),
             training_props=dict(
                 initial_epoch=args.initial_epoch,
-                input_window_stride=args.input_window_stride
+                input_window_stride=args.input_window_stride,
+                checkpoint_epoch_interval=args.checkpoint_epoch_interval
             ),
             resume_train_model_path=args.resume_train_model_path,
             transfer_learning_config=get_transfer_learning_config_for_parsed_args(args),

--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli_args.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli_args.py
@@ -335,6 +335,12 @@ def add_train_arguments(parser: argparse.ArgumentParser):
     output_group = parser.add_argument_group('output')
     add_output_argument(output_group)
     output_group.add_argument("--checkpoint", help="directory where to save a checkpoint model")
+    output_group.add_argument(
+        "--checkpoint-epoch-interval",
+        type=int,
+        default=1,
+        help="save checkpoints every n epochs"
+    )
 
     parser.add_argument(
         "--embedding", default="glove-6B-50d",

--- a/sciencebeam_trainer_delft/sequence_labelling/trainer.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/trainer.py
@@ -29,6 +29,7 @@ LOGGER = logging.getLogger(__name__)
 def get_callbacks(
         model_saver: ModelSaver,
         log_dir: str = None,
+        log_period: int = 1,
         valid: tuple = (),
         early_stopping: bool = True,
         early_stopping_patience: int = 5,
@@ -54,6 +55,7 @@ def get_callbacks(
         assert model_saver
         save_callback = ModelWithMetadataCheckpoint(
             os.path.join(log_dir, epoch_dirname),
+            period=log_period,
             model_saver=model_saver,
             monitor='f1',
             meta=meta
@@ -222,6 +224,7 @@ class Trainer(_Trainer):
             callbacks = get_callbacks(
                 model_saver=self.model_saver,
                 log_dir=self.checkpoint_path,
+                log_period=self.training_config.checkpoint_epoch_interval,
                 early_stopping=True,
                 early_stopping_patience=self.training_config.patience,
                 valid=(validation_generator, self.preprocessor),


### PR DESCRIPTION
For small models / datasets, it might be better to have a larger gap between checkpoints.
This just passes the `--checkpoint-epoch-interval` value on as the `period` value to `ModelCheckpoint`.