### PR TITLE
removed char lstm statefulness

### DIFF
--- a/sciencebeam_trainer_delft/sequence_labelling/models.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/models.py
@@ -98,8 +98,7 @@ class CustomBidLSTM_CRF(CustomModel):
             chars = TimeDistributed(
                 Bidirectional(LSTM(
                     config.num_char_lstm_units,
-                    return_sequences=False,
-                    stateful=stateful
+                    return_sequences=False
                 )),
                 name='char_lstm'
             )(char_embeddings)


### PR DESCRIPTION
Specifying stateful on the char lstm doesn't seem to make sense (if enabled globally).
It was really just meant to be for the word level lstm.
(perhaps that would make it slightly faster)