### PR TITLE
stream tag result to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,12 +560,18 @@ The output can be redirected to a diff file and viewed using a specialised tool 
 Example [unidiff](https://en.wikipedia.org/wiki/Diff#Unified_format) result:
 
 ```text
---- document_1.expected
-+++ document_1.actual
-@@ -0,156 +0,156 @@
- Markov markov M Ma Mar Mark v ov kov rkov BLOCKSTART LINESTART NEWFONT HIGHERFONT 0 0 0 INITCAP NODIGIT 0 0 0 0 0 0 0 0 0 0 NOPUNCT 0 0 B-<title>
- Chain chain C Ch Cha Chai n in ain hain BLOCKIN LINEIN SAMEFONT SAMEFONTSIZE 0 0 0 INITCAP NODIGIT 0 0 1 0 0 0 0 0 0 0 NOPUNCT 0 0 I-<title>
+--- header_document_000002.expected
++++ header_document_000002.actual
+@@ -1,21 +1,21 @@
+ Translucent translucent T Tr Tra Tran t nt ent cent BLOCKSTART LINESTART NEWFONT HIGHERFONT 1 0 0 INITCAP NODIGIT 0 0 1 0 0 0 0 0 0 0 NOPUNCT 0 0 B-<title>
+ Sums sums S Su Sum Sums s ms ums Sums BLOCKIN LINEIN SAMEFONT SAMEFONTSIZE 1 0 0 INITCAP NODIGIT 0 0 1 0 0 0 0 0 0 0 NOPUNCT 0 0 I-<title>
+ : : : : : : : : : : BLOCKIN LINEIN SAMEFONT SAMEFONTSIZE 1 0 0 ALLCAP NODIGIT 1 0 0 0 0 0 0 0 0 0 PUNCT 0 0 I-<title>
+ A a A A A A A A A A BLOCKIN LINEIN SAMEFONT SAMEFONTSIZE 1 0 0 ALLCAP NODIGIT 1 0 1 0 0 0 0 0 0 0 NOPUNCT 0 0 I-<title>
+ Foundation foundation F Fo Fou Foun n on ion tion BLOCKIN LINEIN SAMEFONT SAMEFONTSIZE 1 0 0 INITCAP NODIGIT 0 0 1 0 0 0 0 0 0 0 NOPUNCT 0 0 I-<title>
+ for for f fo for for r or for for BLOCKIN LINEEND SAMEFONT SAMEFONTSIZE 1 0 0 NOCAPS NODIGIT 0 0 1 0 0 0 0 0 0 0 NOPUNCT 0 0 I-<title>
 ...
+ - - - - - - - - - - BLOCKIN LINEEND SAMEFONT SAMEFONTSIZE 0 0 0 ALLCAP NODIGIT 1 0 0 0 0 0 0 0 0 1 HYPHEN 0 0 I-<pubnum>
+ - - - - - - - - - - BLOCKIN LINEIN SAMEFONT SAMEFONTSIZE 0 0 0 ALLCAP NODIGIT 1 0 0 0 0 0 0 0 0 1 HYPHEN 0 0 I-<pubnum>
  95 95 9 95 95 95 5 95 95 95 BLOCKIN LINEIN SAMEFONT SAMEFONTSIZE 0 0 0 NOCAPS ALLDIGIT 0 0 0 0 0 0 0 0 0 0 NOPUNCT 0 0 I-<pubnum>
  - - - - - - - - - - BLOCKIN LINEIN SAMEFONT SAMEFONTSIZE 0 0 0 ALLCAP NODIGIT 1 0 0 0 0 0 0 0 0 1 HYPHEN 0 0 I-<pubnum>
 -of of o of of of f of of of BLOCKIN LINEIN SAMEFONT SAMEFONTSIZE 0 0 0 NOCAPS NODIGIT 0 0 1 0 0 0 0 0 0 0 NOPUNCT 0 0 I-<affiliation>

--- a/sciencebeam_trainer_delft/sequence_labelling/tag_formatter.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tag_formatter.py
@@ -169,7 +169,7 @@ def iter_format_document_list_tag_result_as_data_unidiff(
             document_tag_result=document_tag_result,
             document_expected_tag_result=expected_tag_result[document_index],
             document_features=features[document_index],
-            document_name='document_' + str(1 + document_index)
+            document_name='document_%06d' % (1 + document_index)
         )
 
 

--- a/sciencebeam_trainer_delft/sequence_labelling/tag_formatter.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tag_formatter.py
@@ -63,26 +63,39 @@ def format_list_tag_result_as_json(
     return json.dumps(output_props, indent=2, cls=CustomJsonEncoder)
 
 
-def to_data_lines(
-        features: np.array,
-        annotations: List[List[Tuple[str, str]]]) -> List[str]:
-    return [
+def iter_to_data_lines(
+    features: np.array,
+    annotations: List[List[Tuple[str, str]]]
+) -> Iterable[str]:
+    return (
         ' '.join([token_annoation[0]] + list(token_features) + [token_annoation[1]])
         for line_annotations, line_features in zip(annotations, features.tolist())
         for token_annoation, token_features in zip(line_annotations, line_features)
-    ]
+    )
 
 
-def format_list_tag_result_as_data(
+def to_data_lines(*args, **kwargs) -> List[str]:
+    return list(iter_to_data_lines(*args, **kwargs))
+
+
+def iter_format_list_tag_result_as_data(
         tag_result: List[List[Tuple[str, str]]],
         texts: np.array = None,  # pylint: disable=unused-argument
         features: np.array = None,
         model_name: str = None) -> str:  # pylint: disable=unused-argument
     assert features is not None
-    return '\n'.join(to_data_lines(
+    data_text_iterable = iter_to_data_lines(
         features=features,
         annotations=tag_result
-    ))
+    )
+    for document_index, data_text in enumerate(data_text_iterable):
+        if document_index > 0:
+            yield '\n'
+        yield data_text
+
+
+def format_list_tag_result_as_data(*args, **kwargs) -> str:
+    return ''.join(iter_format_list_tag_result_as_data(*args, **kwargs))
 
 
 def iter_simple_unidiff(
@@ -160,34 +173,36 @@ def iter_format_document_list_tag_result_as_data_unidiff(
         )
 
 
-def format_list_tag_result_as_data_unidiff(
-        tag_result: List[List[Tuple[str, str]]],
-        expected_tag_result: List[Tuple[str, str]] = None,
-        texts: np.ndarray = None,  # pylint: disable=unused-argument
-        features: np.ndarray = None,
-        model_name: str = None) -> str:  # pylint: disable=unused-argument
+def iter_format_list_tag_result_as_data_unidiff(
+    tag_result: List[List[Tuple[str, str]]],
+    expected_tag_result: List[Tuple[str, str]] = None,
+    texts: np.ndarray = None,  # pylint: disable=unused-argument
+    features: np.ndarray = None,
+    model_name: str = None  # pylint: disable=unused-argument
+) -> Iterable[str]:
     assert expected_tag_result
-    return ''.join(iter_format_document_list_tag_result_as_data_unidiff(
+    yield from iter_format_document_list_tag_result_as_data_unidiff(
         tag_result=tag_result,
         expected_tag_result=expected_tag_result,
         features=features
-    ))
+    )
 
 
-def to_flat_text(texts: np.array) -> str:
-    return '\n'.join([
-        ' '.join(line_tokens)
-        for line_tokens in texts
-    ])
+def iter_to_flat_text(texts: np.array) -> Iterable[str]:
+    for document_index, line_tokens in enumerate(texts):
+        if document_index > 0:
+            yield '\n'
+        yield ' '.join(line_tokens)
 
 
-def format_list_tag_result_as_text(
-        tag_result: List[List[Tuple[str, str]]],  # pylint: disable=unused-argument
-        texts: np.array = None,
-        features: np.array = None,  # pylint: disable=unused-argument
-        model_name: str = None) -> str:  # pylint: disable=unused-argument
+def iter_format_list_tag_result_as_text(
+    tag_result: List[List[Tuple[str, str]]],  # pylint: disable=unused-argument
+    texts: np.array = None,
+    features: np.array = None,  # pylint: disable=unused-argument
+    model_name: str = None  # pylint: disable=unused-argument
+) -> Iterable[str]:
     assert texts is not None
-    return to_flat_text(texts=texts)
+    yield from iter_to_flat_text(texts=texts)
 
 
 def get_xml_tag_for_annotation_label(annotation_label: str) -> str:
@@ -246,17 +261,24 @@ def iter_annotations_xml_text(
         yield '  </p>\n'
 
 
-def format_list_tag_result_as_xml(
-        tag_result: List[List[Tuple[str, str]]],
-        texts: np.array = None,  # pylint: disable=unused-argument
-        features: np.array = None,  # pylint: disable=unused-argument
-        model_name: str = None) -> str:  # pylint: disable=unused-argument
-    return '<xml>\n%s</xml>' % ''.join(iter_annotations_xml_text(
+def iter_format_list_tag_result_as_xml(
+    tag_result: List[List[Tuple[str, str]]],
+    texts: np.array = None,  # pylint: disable=unused-argument
+    features: np.array = None,  # pylint: disable=unused-argument
+    model_name: str = None  # pylint: disable=unused-argument
+) -> Iterable[str]:
+    yield '<xml>\n'
+    yield from iter_annotations_xml_text(
         annotations=tag_result
-    ))
+    )
+    yield '</xml>'
 
 
-def format_list_tag_result_as_xml_diff(
+def format_list_tag_result_as_xml(*args, **kwargs) -> str:
+    return ''.join(iter_format_list_tag_result_as_xml(*args, **kwargs))
+
+
+def iter_format_list_tag_result_as_xml_diff(
         tag_result: List[List[Tuple[str, str]]],
         expected_tag_result: List[Tuple[str, str]] = None,
         texts: np.array = None,  # pylint: disable=unused-argument
@@ -265,51 +287,58 @@ def format_list_tag_result_as_xml_diff(
     assert expected_tag_result
     actual_xml = format_list_tag_result_as_xml(tag_result)
     expected_xml = format_list_tag_result_as_xml(expected_tag_result)
-    return ''.join(difflib.ndiff(
+    yield from difflib.ndiff(
         expected_xml.splitlines(keepends=True),
         actual_xml.splitlines(keepends=True)
-    ))
+    )
 
 
-def format_list_tag_result(
+def iter_format_list_tag_result(
         *args,
         output_format: str,
         expected_tag_result: List[Tuple[str, str]] = None,
-        **kwargs) -> str:
+        **kwargs) -> Iterable[str]:
     if output_format == TagOutputFormats.JSON:
-        return format_list_tag_result_as_json(*args, **kwargs)
+        yield format_list_tag_result_as_json(*args, **kwargs)
+        return
     if output_format == TagOutputFormats.DATA:
-        return format_list_tag_result_as_data(*args, **kwargs)
+        yield from iter_format_list_tag_result_as_data(*args, **kwargs)
+        return
     if output_format == TagOutputFormats.DATA_UNIDIFF:
-        return format_list_tag_result_as_data_unidiff(
+        yield from iter_format_list_tag_result_as_data_unidiff(
             *args,
             expected_tag_result=expected_tag_result,
             **kwargs
         )
+        return
     if output_format == TagOutputFormats.TEXT:
-        return format_list_tag_result_as_text(*args, **kwargs)
+        yield from iter_format_list_tag_result_as_text(*args, **kwargs)
+        return
     if output_format == TagOutputFormats.XML:
-        return format_list_tag_result_as_xml(*args, **kwargs)
+        yield from iter_format_list_tag_result_as_xml(*args, **kwargs)
+        return
     if output_format == TagOutputFormats.XML_DIFF:
-        return format_list_tag_result_as_xml_diff(
+        yield from iter_format_list_tag_result_as_xml_diff(
             *args,
             expected_tag_result=expected_tag_result,
             **kwargs
         )
+        return
     raise ValueError('unrecognised output format: %s' % output_format)
 
 
-def format_tag_result(
+def iter_format_tag_result(
         tag_result: Union[dict, list],
         output_format: str,
         expected_tag_result: List[Tuple[str, str]] = None,
         texts: np.array = None,
         features: np.array = None,
-        model_name: str = None) -> str:
+        model_name: str = None) -> Iterable[str]:
     if isinstance(tag_result, dict):
         assert output_format == TagOutputFormats.JSON
-        return format_json_tag_result_as_json(tag_result)
-    return format_list_tag_result(
+        yield format_json_tag_result_as_json(tag_result)
+        return
+    yield from iter_format_list_tag_result(
         tag_result,
         output_format=output_format,
         expected_tag_result=expected_tag_result,
@@ -317,3 +346,7 @@ def format_tag_result(
         features=features,
         model_name=model_name
     )
+
+
+def format_tag_result(*args, **kwargs) -> str:
+    return ''.join(iter_format_tag_result(*args, **kwargs))

--- a/sciencebeam_trainer_delft/sequence_labelling/tag_formatter.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tag_formatter.py
@@ -50,7 +50,7 @@ def format_json_tag_result_as_json(tag_result: dict) -> str:
 
 
 def format_list_tag_result_as_json(
-        tag_result: List[List[Tuple[str, str]]],
+        tag_result: Iterable[List[Tuple[str, str]]],
         texts: np.array = None,
         features: np.array = None,
         model_name: str = None) -> str:
@@ -58,7 +58,7 @@ def format_list_tag_result_as_json(
         'model': model_name,
         'texts': np.array(texts).tolist(),
         'features': np.array(features).tolist() if features is not None else None,
-        'annotations': tag_result
+        'annotations': list(tag_result)
     }
     return json.dumps(output_props, indent=2, cls=CustomJsonEncoder)
 
@@ -79,7 +79,7 @@ def to_data_lines(*args, **kwargs) -> List[str]:
 
 
 def iter_format_list_tag_result_as_data(
-        tag_result: List[List[Tuple[str, str]]],
+        tag_result: Iterable[List[Tuple[str, str]]],
         texts: np.array = None,  # pylint: disable=unused-argument
         features: np.array = None,
         model_name: str = None) -> str:  # pylint: disable=unused-argument
@@ -160,7 +160,7 @@ def iter_format_document_tag_result_as_data_unidiff(
 
 
 def iter_format_document_list_tag_result_as_data_unidiff(
-    tag_result: List[List[Tuple[str, str]]],
+    tag_result: Iterable[List[Tuple[str, str]]],
     expected_tag_result: List[List[Tuple[str, str]]],
     features: np.ndarray
 ) -> Iterable[str]:
@@ -174,7 +174,7 @@ def iter_format_document_list_tag_result_as_data_unidiff(
 
 
 def iter_format_list_tag_result_as_data_unidiff(
-    tag_result: List[List[Tuple[str, str]]],
+    tag_result: Iterable[List[Tuple[str, str]]],
     expected_tag_result: List[Tuple[str, str]] = None,
     texts: np.ndarray = None,  # pylint: disable=unused-argument
     features: np.ndarray = None,
@@ -196,7 +196,7 @@ def iter_to_flat_text(texts: np.array) -> Iterable[str]:
 
 
 def iter_format_list_tag_result_as_text(
-    tag_result: List[List[Tuple[str, str]]],  # pylint: disable=unused-argument
+    tag_result: Iterable[List[Tuple[str, str]]],  # pylint: disable=unused-argument
     texts: np.array = None,
     features: np.array = None,  # pylint: disable=unused-argument
     model_name: str = None  # pylint: disable=unused-argument
@@ -262,7 +262,7 @@ def iter_annotations_xml_text(
 
 
 def iter_format_list_tag_result_as_xml(
-    tag_result: List[List[Tuple[str, str]]],
+    tag_result: Iterable[List[Tuple[str, str]]],
     texts: np.array = None,  # pylint: disable=unused-argument
     features: np.array = None,  # pylint: disable=unused-argument
     model_name: str = None  # pylint: disable=unused-argument
@@ -279,7 +279,7 @@ def format_list_tag_result_as_xml(*args, **kwargs) -> str:
 
 
 def iter_format_list_tag_result_as_xml_diff(
-        tag_result: List[List[Tuple[str, str]]],
+        tag_result: Iterable[List[Tuple[str, str]]],
         expected_tag_result: List[Tuple[str, str]] = None,
         texts: np.array = None,  # pylint: disable=unused-argument
         features: np.array = None,  # pylint: disable=unused-argument
@@ -328,7 +328,7 @@ def iter_format_list_tag_result(
 
 
 def iter_format_tag_result(
-        tag_result: Union[dict, list],
+        tag_result: Union[dict, list, Iterable],
         output_format: str,
         expected_tag_result: List[Tuple[str, str]] = None,
         texts: np.array = None,

--- a/sciencebeam_trainer_delft/sequence_labelling/tag_formatter.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tag_formatter.py
@@ -162,14 +162,15 @@ def iter_format_document_tag_result_as_data_unidiff(
 def iter_format_document_list_tag_result_as_data_unidiff(
     tag_result: Iterable[List[Tuple[str, str]]],
     expected_tag_result: List[List[Tuple[str, str]]],
-    features: np.ndarray
+    features: np.ndarray,
+    document_name_prefix: str
 ) -> Iterable[str]:
     for document_index, document_tag_result in enumerate(tag_result):
         yield from iter_format_document_tag_result_as_data_unidiff(
             document_tag_result=document_tag_result,
             document_expected_tag_result=expected_tag_result[document_index],
             document_features=features[document_index],
-            document_name='document_%06d' % (1 + document_index)
+            document_name='%s%06d' % (document_name_prefix, 1 + document_index)
         )
 
 
@@ -181,10 +182,14 @@ def iter_format_list_tag_result_as_data_unidiff(
     model_name: str = None  # pylint: disable=unused-argument
 ) -> Iterable[str]:
     assert expected_tag_result
+    document_name_prefix = 'document_'
+    if model_name:
+        document_name_prefix = model_name + '_' + document_name_prefix
     yield from iter_format_document_list_tag_result_as_data_unidiff(
         tag_result=tag_result,
         expected_tag_result=expected_tag_result,
-        features=features
+        features=features,
+        document_name_prefix=document_name_prefix
     )
 
 

--- a/sciencebeam_trainer_delft/sequence_labelling/tagger.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tagger.py
@@ -103,6 +103,7 @@ def predict_texts_with_sliding_window_if_enabled(
         desc='%s: ' % predict_generator.name,
         unit='batch'
     )
+    completed_curser = 0
     for batch_window_indices_and_offsets in batch_window_indices_and_offsets_iterable:
         LOGGER.debug(
             'predict batch_window_indices_and_offsets: %s',
@@ -118,12 +119,13 @@ def predict_texts_with_sliding_window_if_enabled(
             batch_window_indices_and_offsets, batch_predictions
         ):
             text_index, text_offset = window_indices_and_offsets
+            current_prediction_list = prediction_list_list[text_index]
             LOGGER.debug(
                 'prediction_list_list[%d]: %s',
                 text_index,
-                prediction_list_list[text_index]
+                current_prediction_list
             )
-            current_offset = sum((len(a) for a in prediction_list_list[text_index]))
+            current_offset = sum((len(a) for a in current_prediction_list))
             if current_offset > text_offset:
                 # skip over the overlapping window
                 seq_predictions = seq_predictions[(current_offset - text_offset):, :]
@@ -133,17 +135,19 @@ def predict_texts_with_sliding_window_if_enabled(
             ), "expected %d to be %d" % (
                 current_offset, text_offset
             )
-            prediction_list_list[text_index].append(seq_predictions)
+            current_prediction_list.append(seq_predictions)
+            next_offset = sum((len(a) for a in current_prediction_list))
+            is_complete = (next_offset >= len(texts[text_index]))
+            LOGGER.debug(
+                'is_complete: %s, text_index=%d, completed_curser=%d, next_offset=%d, textlen=%d',
+                is_complete, text_index, completed_curser, next_offset, len(texts[text_index])
+            )
+            if (is_complete and text_index == completed_curser):
+                yield np.concatenate(current_prediction_list, axis=0)
+                completed_curser += 1
 
-    preds_concatenated_list = [
-        np.concatenate(
-            prediction_list,
-            axis=0
-        )
-        for prediction_list in prediction_list_list
-    ]
-    LOGGER.debug('preds_concatenated_list: %s', preds_concatenated_list)
-    return preds_concatenated_list
+    for prediction_list in prediction_list_list[completed_curser:]:
+        yield np.concatenate(prediction_list, axis=0)
 
 
 class Tagger:
@@ -162,18 +166,10 @@ class Tagger:
         self.max_sequence_length = max_sequence_length
         self.input_window_stride = input_window_stride
 
-    def tag(self, texts, output_format, features=None):
+    def iter_tag(
+        self, texts, output_format, features=None
+    ) -> Union[dict, Iterable[List[Tuple[str, str]]]]:
         assert isinstance(texts, list)
-
-        if output_format == 'json':
-            res = {
-                "software": "DeLFT",
-                "date": datetime.datetime.now().isoformat(),
-                "model": self.model.config.model_name,
-                "texts": []
-            }
-        else:
-            list_of_tags = []
 
         preds_concatenated_list = predict_texts_with_sliding_window_if_enabled(
             texts=texts,
@@ -187,6 +183,7 @@ class Tagger:
         )
         for i, pred_item in enumerate(preds_concatenated_list):
             LOGGER.debug('pred_item.shape: %s', pred_item.shape)
+            LOGGER.debug('pred_item=%r', pred_item)
 
             pred = [pred_item]
             text = texts[i]
@@ -201,23 +198,32 @@ class Tagger:
 
             tags = self._get_tags(pred)
             LOGGER.debug('tags: %s', tags)
-            prob = self._get_prob(pred)
 
             if output_format == 'json':
+                prob = self._get_prob(pred)
                 piece = {}
                 piece["text"] = text
                 piece["entities"] = self._build_json_response(
                     tokens, tags, prob, offsets
                 )["entities"]
-                res["texts"].append(piece)
+                yield piece
             else:
                 the_tags = list(zip(tokens, tags))
-                list_of_tags.append(the_tags)
+                yield the_tags
 
+    def tag(
+        self, texts, output_format, features=None
+    ) -> Union[dict, List[List[Tuple[str, str]]]]:
+        result = list(self.iter_tag(texts, output_format, features))
         if output_format == 'json':
-            return res
+            return {
+                "software": "ScienceBeam Trainer DeLFT",
+                "date": datetime.datetime.now().isoformat(),
+                "model": self.model.config.model_name,
+                "texts": result
+            }
         else:
-            return list_of_tags
+            return result
 
     def _get_tags(self, pred):
         pred = np.argmax(pred, -1)

--- a/sciencebeam_trainer_delft/sequence_labelling/tagger.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tagger.py
@@ -36,7 +36,7 @@ def predict_texts_with_sliding_window_if_enabled(
         features: List[List[List[str]]] = None):
     if not texts:
         LOGGER.info('passed in empty texts, model: %s', model_config.model_name)
-        return []
+        return
     should_tokenize = (
         len(texts) > 0  # pylint: disable=len-as-condition
         and isinstance(texts[0], str)

--- a/sciencebeam_trainer_delft/sequence_labelling/tagger.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tagger.py
@@ -25,7 +25,7 @@ def iter_batch_window_indices_and_offsets(
     )
 
 
-def predict_texts_with_sliding_window_if_enabled(
+def iter_predict_texts_with_sliding_window_if_enabled(
         texts: List[Union[str, List[str]]],
         model_config: ModelConfig,
         preprocessor: WordPreprocessor,
@@ -171,7 +171,7 @@ class Tagger:
     ) -> Union[dict, Iterable[List[Tuple[str, str]]]]:
         assert isinstance(texts, list)
 
-        preds_concatenated_list = predict_texts_with_sliding_window_if_enabled(
+        preds_concatenated_iterable = iter_predict_texts_with_sliding_window_if_enabled(
             texts=texts,
             features=features,
             model=self.model,
@@ -181,7 +181,7 @@ class Tagger:
             input_window_stride=self.input_window_stride,
             embeddings=self.embeddings
         )
-        for i, pred_item in enumerate(preds_concatenated_list):
+        for i, pred_item in enumerate(preds_concatenated_iterable):
             LOGGER.debug('pred_item.shape: %s', pred_item.shape)
             LOGGER.debug('pred_item=%r', pred_item)
 

--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/utils.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/utils.py
@@ -42,7 +42,7 @@ from sciencebeam_trainer_delft.sequence_labelling.engines.wapiti_adapters import
 from sciencebeam_trainer_delft.sequence_labelling.tag_formatter import (
     TagOutputFormats,
     get_tag_result,
-    format_tag_result
+    iter_format_tag_result
 )
 
 from sciencebeam_trainer_delft.sequence_labelling.evaluation import (
@@ -748,7 +748,7 @@ def do_tag_input(
         labels=y_all
     )
     LOGGER.debug('actual raw expected_tag_result: %s', expected_tag_result)
-    formatted_tag_result = format_tag_result(
+    formatted_tag_result_iterable = iter_format_tag_result(
         tag_result,
         output_format=tag_output_format,
         expected_tag_result=expected_tag_result,
@@ -756,10 +756,11 @@ def do_tag_input(
         features=features_all,
         model_name=model._get_model_name()  # pylint: disable=protected-access
     )
-    if not formatted_tag_result.endswith('\n'):
-        formatted_tag_result += '\n'
+    # if not formatted_tag_result.endswith('\n'):
+    #     formatted_tag_result += '\n'
     LOGGER.info('tag_result:')
-    print(formatted_tag_result, end='')
+    for text in formatted_tag_result_iterable:
+        print(text, end='')
 
 
 def tag_input(

--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/utils.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/utils.py
@@ -756,8 +756,6 @@ def do_tag_input(
         features=features_all,
         model_name=model._get_model_name()  # pylint: disable=protected-access
     )
-    # if not formatted_tag_result.endswith('\n'):
-    #     formatted_tag_result += '\n'
     LOGGER.info('tag_result:')
     for text in formatted_tag_result_iterable:
         print(text, end='')

--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/utils.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/utils.py
@@ -737,7 +737,7 @@ def do_tag_input(
 
     LOGGER.info('%d input sequences', len(x_all))
 
-    tag_result = model.tag(
+    tag_result = model.iter_tag(
         x_all,
         output_format=None,
         features=features_all

--- a/sciencebeam_trainer_delft/sequence_labelling/wrapper.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/wrapper.py
@@ -540,6 +540,10 @@ class Sequence(_Sequence):
                 features=features
             )
         if self.tag_debug_reporter:
+            if not isinstance(annotations, dict):
+                # the tag debug reporter only supports lists
+                # additionally should not consume the iterable
+                annotations = list(annotations)
             self.tag_debug_reporter.report_tag_results(
                 texts=texts,
                 features=features,

--- a/sciencebeam_trainer_delft/sequence_labelling/wrapper.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/wrapper.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import time
-from typing import Callable, List, Optional, T
+from typing import Callable, Iterable, List, Optional, Tuple, Union, T
 
 import numpy as np
 
@@ -512,8 +512,9 @@ class Sequence(_Sequence):
             print("\n** Best ** model scores - \n")
             print(reports[best_index])
 
-    def tag(  # pylint: disable=arguments-differ
-            self, texts, output_format, features=None):
+    def iter_tag(
+        self, texts, output_format, features=None
+    ) -> Union[dict, Iterable[List[Tuple[str, str]]]]:
         # annotate a list of sentences, return the list of annotations in the
         # specified output_format
         self._require_model()
@@ -525,14 +526,19 @@ class Sequence(_Sequence):
             input_window_stride=self.input_window_stride,
             preprocessor=self.p
         )
-        start_time = time.time()
-        annotations = tagger.tag(
-            list(texts), output_format,
-            features=features
-        )
-        runtime = round(time.time() - start_time, 3)
         if output_format == 'json':
+            start_time = time.time()
+            annotations = tagger.tag(
+                list(texts), output_format,
+                features=features
+            )
+            runtime = round(time.time() - start_time, 3)
             annotations["runtime"] = runtime
+        else:
+            annotations = tagger.iter_tag(
+                list(texts), output_format,
+                features=features
+            )
         if self.tag_debug_reporter:
             self.tag_debug_reporter.report_tag_results(
                 texts=texts,
@@ -541,6 +547,12 @@ class Sequence(_Sequence):
                 model_name=self._get_model_name()
             )
         return annotations
+
+    def tag(self, *args, **kwargs) -> Union[dict, List[List[Tuple[str, str]]]]:
+        iterable_or_dict = self.iter_tag(*args, **kwargs)
+        if isinstance(iterable_or_dict, dict):
+            return iterable_or_dict
+        return list(iterable_or_dict)
 
     def _require_model(self):
         if not self.model:

--- a/tests/sequence_labelling/tag_formatter_test.py
+++ b/tests/sequence_labelling/tag_formatter_test.py
@@ -123,8 +123,8 @@ class TestFormatTagResult:
         )
         LOGGER.debug('result:\n%s', result)
         assert result.splitlines() == [
-            '--- document_1.expected',
-            '+++ document_1.actual',
+            '--- document_000001.expected',
+            '+++ document_000001.actual',
             '@@ -1,3 +1,3 @@',
             ' token1 feat1.1 feat1.2 B-tag1',
             ' token2 feat2.1 feat2.2 I-tag1',
@@ -150,15 +150,15 @@ class TestFormatTagResult:
         )
         LOGGER.debug('result:\n%s', result)
         assert result.splitlines() == [
-            '--- document_1.expected',
-            '+++ document_1.actual',
+            '--- document_000001.expected',
+            '+++ document_000001.actual',
             '@@ -1,3 +1,3 @@',
             ' token1.1 feat1.1.1 B-tag1',
             ' token1.2 feat1.2.1 I-tag1',
             '-token1.3 feat1.3.1 B-tag3',
             '+token1.3 feat1.3.1 B-tag2',
-            '--- document_2.expected',
-            '+++ document_2.actual',
+            '--- document_000002.expected',
+            '+++ document_000002.actual',
             '@@ -1,3 +1,3 @@',
             ' token2.1 feat2.1.1 B-tag1',
             ' token2.2 feat2.2.1 I-tag1',

--- a/tests/sequence_labelling/tag_formatter_test.py
+++ b/tests/sequence_labelling/tag_formatter_test.py
@@ -1,6 +1,8 @@
 
 import json
 import logging
+from typing import Iterable
+
 import numpy as np
 
 from sciencebeam_trainer_delft.sequence_labelling.tag_formatter import (
@@ -51,6 +53,10 @@ def format_tag_result(*args, **kwargs):
     return result
 
 
+def to_iterable(some_list: list) -> Iterable:
+    return (value for value in some_list)
+
+
 class TestGetTagResult:
     def test_should_combine_text_with_labels(self):
         assert get_tag_result(
@@ -81,7 +87,7 @@ class TestFormatTagResult:
 
     def test_should_format_tag_list_result_as_json(self):
         result = json.loads(format_tag_result(
-            tag_result=ANNOTATIONS_1,
+            tag_result=to_iterable(ANNOTATIONS_1),
             output_format=TagOutputFormats.JSON,
             texts=TEXTS_1,
             features=FEATURES_1,
@@ -94,7 +100,7 @@ class TestFormatTagResult:
 
     def test_should_format_tag_list_result_as_data(self):
         result = format_tag_result(
-            tag_result=ANNOTATIONS_1,
+            tag_result=to_iterable(ANNOTATIONS_1),
             output_format=TagOutputFormats.DATA,
             texts=TEXTS_1,
             features=FEATURES_1,
@@ -104,7 +110,9 @@ class TestFormatTagResult:
 
     def test_should_format_tag_list_result_as_data_unidiff_and_combined_tags(self):
         result = format_tag_result(
-            tag_result=[[['token1', 'B-tag1'], ['token2', 'I-tag1'], ['token3', 'B-tag2']]],
+            tag_result=to_iterable(
+                [[['token1', 'B-tag1'], ['token2', 'I-tag1'], ['token3', 'B-tag2']]]
+            ),
             expected_tag_result=[
                 [['token1', 'B-tag1'], ['token2', 'I-tag1'], ['token3', 'B-tag3']]
             ],
@@ -126,10 +134,10 @@ class TestFormatTagResult:
 
     def test_should_format_tag_data_unidiff_with_multiple_changes(self):
         result = format_tag_result(
-            tag_result=[
+            tag_result=to_iterable([
                 [['token1.1', 'B-tag1'], ['token1.2', 'I-tag1'], ['token1.3', 'B-tag2']],
                 [['token2.1', 'B-tag1'], ['token2.2', 'I-tag1'], ['token2.3', 'B-tag2']]
-            ],
+            ]),
             expected_tag_result=[
                 [['token1.1', 'B-tag1'], ['token1.2', 'I-tag1'], ['token1.3', 'B-tag3']],
                 [['token2.1', 'B-tag1'], ['token2.2', 'I-tag1'], ['token2.3', 'B-tag3']]
@@ -174,7 +182,7 @@ class TestFormatTagResult:
 
     def test_should_format_tag_list_result_as_text(self):
         result = format_tag_result(
-            tag_result=ANNOTATIONS_1,
+            tag_result=to_iterable(ANNOTATIONS_1),
             output_format=TagOutputFormats.TEXT,
             texts=TEXTS_1,
             features=FEATURES_1,
@@ -184,7 +192,7 @@ class TestFormatTagResult:
 
     def test_should_format_tag_list_result_as_xml(self):
         result = format_tag_result(
-            tag_result=ANNOTATIONS_1,
+            tag_result=to_iterable(ANNOTATIONS_1),
             output_format=TagOutputFormats.XML,
             texts=TEXTS_1,
             features=FEATURES_1,
@@ -194,7 +202,9 @@ class TestFormatTagResult:
 
     def test_should_format_tag_list_result_as_xml_and_combined_tags(self):
         result = format_tag_result(
-            tag_result=[[['token1', 'B-tag1'], ['token2', 'I-tag1'], ['token3', 'B-tag2']]],
+            tag_result=to_iterable(
+                [[['token1', 'B-tag1'], ['token2', 'I-tag1'], ['token3', 'B-tag2']]]
+            ),
             output_format=TagOutputFormats.XML
         )
         assert result.splitlines() == [
@@ -208,7 +218,9 @@ class TestFormatTagResult:
 
     def test_should_format_tag_list_result_as_xml_and_include_text_without_tags(self):
         result = format_tag_result(
-            tag_result=[[['token1', 'O'], ['token2', 'O'], ['token3', 'B-tag2']]],
+            tag_result=to_iterable(
+                [[['token1', 'O'], ['token2', 'O'], ['token3', 'B-tag2']]]
+            ),
             output_format=TagOutputFormats.XML
         )
         assert result.splitlines() == [
@@ -222,7 +234,9 @@ class TestFormatTagResult:
 
     def test_should_format_tag_list_result_as_xml_diff_and_combined_tags(self):
         result = format_tag_result(
-            tag_result=[[['token1', 'B-tag1'], ['token2', 'I-tag1'], ['token3', 'B-tag2']]],
+            tag_result=to_iterable(
+                [[['token1', 'B-tag1'], ['token2', 'I-tag1'], ['token3', 'B-tag2']]]
+            ),
             expected_tag_result=[
                 [['token1', 'B-tag1'], ['token2', 'I-tag1'], ['token3', 'B-tag3']]
             ],


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/125

This streams the tag results, so that results are displayed sooner and it doesn't increase the memory for at least the tagging result (the input data is still read into memory in full).