### PR TITLE
added support for --tag-output-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,13 +449,15 @@ It can also be saved using `--eval-output-path`.
 
 ### Tag Sub Command
 
-The `tag` sub command supports multiple output formats:
+The `tag` sub command supports multiple output formats (`--tag-output-path`):
 
 - `json`: more detailed tagging output
 - `data`: data output with features but label being replaced by predicted label
 - `text`: not really a tag output as it just outputs the input text
 - `xml`: uses predicted labels as XML elements
 - `xml_diff`: same as `xml` but it is showing a diff between expected and predicted results
+
+The output will be written to the path specified via `--tag-output-path` if present. Otherwise it will be written to *stdout*.
 
 #### XML Output Example
 
@@ -552,10 +554,10 @@ python -m sciencebeam_trainer_delft.sequence_labelling.grobid_trainer \
     --model-path="https://github.com/kermitt2/grobid/raw/0.5.6/grobid-home/models/header/" \
     --limit="2" \
     --tag-output-format="data_unidiff" \
-    --quiet
+    --tag-output-path="/tmp/test.diff"
 ```
 
-The output can be redirected to a diff file and viewed using a specialised tool (such as [Kompare](https://en.wikipedia.org/wiki/Kompare)).
+The output can be viewed using a specialised tool (such as [Kompare](https://en.wikipedia.org/wiki/Kompare)).
 
 Example [unidiff](https://en.wikipedia.org/wiki/Diff#Unified_format) result:
 

--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli.py
@@ -58,6 +58,7 @@ from sciencebeam_trainer_delft.sequence_labelling.tools.grobid_trainer.cli_args 
     add_stateful_argument,
     add_input_window_stride_argument,
     add_tag_output_format_argument,
+    add_tag_output_path_argument,
     add_model_positional_argument,
     create_argument_parser,
     process_args
@@ -391,11 +392,13 @@ class TagSubCommand(GrobidTrainerSubCommand):
         add_input_window_stride_argument(parser)
         add_model_path_argument(parser, required=True, help='directory to load the model from')
         add_tag_output_format_argument(parser)
+        add_tag_output_path_argument(parser)
 
     def do_run(self, args: argparse.Namespace):
         tag_input(
             model_path=args.model_path,
             tag_output_format=args.tag_output_format,
+            tag_output_path=args.tag_output_path,
             stateful=args.stateful,
             input_window_stride=args.input_window_stride,
             **self.get_common_args(args)
@@ -407,12 +410,14 @@ class WapitiTagSubCommand(GrobidTrainerSubCommand):
         add_common_arguments(parser, max_sequence_length_default=None)
         add_model_path_argument(parser, required=True, help='directory to load the model from')
         add_tag_output_format_argument(parser)
+        add_tag_output_path_argument(parser)
         add_wapiti_install_arguments(parser)
 
     def do_run(self, args: argparse.Namespace):
         wapiti_tag_input(
             model_path=args.model_path,
             tag_output_format=args.tag_output_format,
+            tag_output_path=args.tag_output_path,
             model=args.model,
             input_paths=args.input,
             limit=args.limit,

--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli_args.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli_args.py
@@ -219,6 +219,13 @@ def add_tag_output_format_argument(parser: argparse.ArgumentParser, **kwargs):
     )
 
 
+def add_tag_output_path_argument(parser: argparse.ArgumentParser):
+    parser.add_argument(
+        "--tag-output-path",
+        help='If specified, saves the tag result to the specified path'
+    )
+
+
 def add_output_argument(parser: argparse.ArgumentParser, **kwargs):
     parser.add_argument("--output", help="directory where to save a trained model", **kwargs)
 

--- a/sciencebeam_trainer_delft/utils/io.py
+++ b/sciencebeam_trainer_delft/utils/io.py
@@ -204,7 +204,9 @@ def list_files(directory_path: str) -> List[str]:
 @contextmanager
 def auto_uploading_output_file(filepath: str, mode: str = 'w', **kwargs):
     if not is_external_location(filepath):
-        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+        file_dirname = os.path.dirname(filepath)
+        if file_dirname:
+            os.makedirs(os.path.dirname(filepath), exist_ok=True)
         with open(filepath, mode=mode, **kwargs) as fp:
             yield fp
             return


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/125

It may be more convenient to explicitly specify an output file rather than redirecting stdout.
In particular, this can be helpful when running on a remote vm (cloud) and saving it to cloud storage.