### PR TITLE
added --char-input-mask-zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ python -m sciencebeam_trainer_delft.sequence_labelling.grobid_trainer \
     --early-stopping-patience="3" \
     --char-embedding-size="11" \
     --char-lstm-units="12" \
+    --char-input-mask-zero \
     --char-input-dropout="0.3" \
     --char-lstm-dropout="0.3" \
     --max-char-length="13" \
@@ -561,7 +562,7 @@ The output can be viewed using a specialised tool (such as [Kompare](https://en.
 
 Example [unidiff](https://en.wikipedia.org/wiki/Diff#Unified_format) result:
 
-```text
+```diff
 --- header_document_000002.expected
 +++ header_document_000002.actual
 @@ -1,21 +1,21 @@

--- a/sciencebeam_trainer_delft/sequence_labelling/config.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/config.py
@@ -27,6 +27,7 @@ class ModelConfig(_ModelConfig):
             text_feature_indices: List[int] = None,
             concatenated_embeddings_token_count: int = None,
             use_features_indices_input: bool = False,
+            char_input_mask_zero: bool = False,
             char_input_dropout: float = DEFAULT_CHAR_INPUT_DROPOUT,
             char_lstm_dropout: float = DEFAULT_CHAR_LSTM_DROPOUT,
             stateful: bool = False,
@@ -47,6 +48,7 @@ class ModelConfig(_ModelConfig):
         self.use_features = use_features
         self.max_feature_size = max_feature_size
         self.use_features_indices_input = use_features_indices_input
+        self.char_input_mask_zero = char_input_mask_zero
         self.char_input_dropout = char_input_dropout
         self.char_lstm_dropout = char_lstm_dropout
         self.stateful = stateful

--- a/sciencebeam_trainer_delft/sequence_labelling/models.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/models.py
@@ -90,8 +90,7 @@ class CustomBidLSTM_CRF(CustomModel):
             char_embeddings = TimeDistributed(Embedding(
                 input_dim=config.char_vocab_size,
                 output_dim=config.char_embedding_size,
-                # mask_zero=True,
-                # embeddings_initializer=RandomUniform(minval=-0.5, maxval=0.5),
+                mask_zero=config.char_input_mask_zero,
                 name='char_embeddings_embedding'
             ), name='char_embeddings')(char_input)
 

--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli.py
@@ -176,6 +176,7 @@ class GrobidTrainerSubCommand(SubCommand):
             patience=args.early_stopping_patience,
             config_props=dict(
                 max_char_length=args.max_char_length,
+                char_input_mask_zero=args.char_input_mask_zero,
                 char_input_dropout=args.char_input_dropout,
                 char_lstm_dropout=args.char_lstm_dropout,
                 additional_token_feature_indices=args.additional_token_feature_indices,

--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli_args.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli_args.py
@@ -483,5 +483,6 @@ def process_args(args: argparse.Namespace) -> argparse.Namespace:
 
 def create_argument_parser() -> argparse.ArgumentParser:
     return argparse.ArgumentParser(
-        description="Trainer for GROBID models"
+        description="Trainer for GROBID models",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )

--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli_args.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli_args.py
@@ -380,6 +380,10 @@ def add_train_arguments(parser: argparse.ArgumentParser):
         help="number of list units for chars"
     )
     parser.add_argument(
+        "--char-input-mask-zero", action='store_true',
+        help="enables masking of zero for the char input"
+    )
+    parser.add_argument(
         "--char-input-dropout", type=float, default=DEFAULT_CHAR_INPUT_DROPOUT,
         help="dropout for char input"
     )

--- a/sciencebeam_trainer_delft/utils/cli.py
+++ b/sciencebeam_trainer_delft/utils/cli.py
@@ -80,7 +80,8 @@ class SubCommandProcessor:
 
     def get_parser(self) -> argparse.ArgumentParser:
         parser = argparse.ArgumentParser(
-            description=self.description
+            description=self.description,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter
         )
         self.add_sub_command_parsers(parser)
         return parser
@@ -101,7 +102,8 @@ class SubCommandProcessor:
     def add_sub_command_parsers_to_subparsers(self, subparsers: argparse.ArgumentParser):
         for sub_command in self.sub_commands:
             sub_parser = subparsers.add_parser(
-                sub_command.name, help=sub_command.description
+                sub_command.name, help=sub_command.description,
+                formatter_class=argparse.ArgumentDefaultsHelpFormatter
             )
             sub_command.add_arguments(sub_parser)
             add_default_arguments(sub_parser)


### PR DESCRIPTION
The `segmentation` model with the additional text feature may end up having a lot of padding characters.
This allows the `mask_zero` feature to be used.