### PR TITLE
ignore broken pipe error on tag sub command

### DIFF
--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/utils.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/utils.py
@@ -823,8 +823,11 @@ def do_tag_input(
                 fp.write(text)
     else:
         LOGGER.info('writing tag_result to stdout')
-        for text in formatted_tag_result_iterable:
-            print(text, end='')
+        try:
+            for text in formatted_tag_result_iterable:
+                print(text, end='')
+        except BrokenPipeError:
+            LOGGER.info('received broken pipe error')
 
 
 def tag_input(


### PR DESCRIPTION
When using the tag sub command, it may be common to pipe it to `head`.
In that case we would receive a `BrokenPipeError` that should be ignored (program should end).