### PR TITLE
fixed unroll text feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Another feature will get added with the *line status* (`LINESTART`, `LINEIN`, `L
 Where the label has a beginning prefix (`B-`), it will get converted to an inside prefix (`I-`) for the remaining tokens
 (see [IOB format](https://en.wikipedia.org/wiki/Inside%E2%80%93outside%E2%80%93beginning_(tagging))).
 At the prediction time, the model will receive the "unrolled" data, wheras the original data will get returned,
-with the majority label for that line (majority without prefix, a beginning prefix will be used if present).
+with the majority label for that line (majority without prefix, a beginning prefix will be used if the label has changed).
 
 Example:
 

--- a/sciencebeam_trainer_delft/sequence_labelling/dataset_transform/unroll_transform.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/dataset_transform/unroll_transform.py
@@ -71,7 +71,7 @@ def get_transformed_features(
     unrolled_token_index: int,
     unrolled_tokens_length: int
 ):
-    return token_features + [get_line_status(unrolled_token_index, unrolled_tokens_length)]
+    return list(token_features) + [get_line_status(unrolled_token_index, unrolled_tokens_length)]
 
 
 class UnrollingTextFeatureDatasetTransformer(DatasetTransformer):

--- a/sciencebeam_trainer_delft/sequence_labelling/tag_formatter.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tag_formatter.py
@@ -102,6 +102,9 @@ def iter_simple_unidiff(
     a, b, fromfile='', tofile='', lineterm='\n',
     force_output: bool = False
 ) -> Iterable[str]:
+    if len(a) > len(b):
+        # truncate expected, as predicted sequences may have truncuated
+        a = a[:len(b)]
     assert len(a) == len(b)
     line_count = len(a)
     is_diff_list = [

--- a/sciencebeam_trainer_delft/sequence_labelling/wrapper.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/wrapper.py
@@ -274,7 +274,8 @@ class Sequence(_Sequence):
             )
             self.dataset_transformer_factory = partial(
                 UnrollingTextFeatureDatasetTransformer,
-                self.model_config.unroll_text_feature_index
+                self.model_config.unroll_text_feature_index,
+                used_features_indices=self.model_config.features_indices
             )
 
     def clear_embedding_cache(self):

--- a/tests/sequence_labelling/data_transform/unroll_transform_test.py
+++ b/tests/sequence_labelling/data_transform/unroll_transform_test.py
@@ -25,7 +25,10 @@ class TestGetLineStatus:
 
 class TestUnrollingTextFeatureDatasetTransformer:
     def test_should_unroll_and_inverse_transform_x_y_and_features_using_list(self):
-        data_transformer = UnrollingTextFeatureDatasetTransformer(2)
+        data_transformer = UnrollingTextFeatureDatasetTransformer(
+            2,
+            used_features_indices=[3]
+        )
         x = [['token1', 'token2']]
         y = [['label1', 'label2']]
         features = [[
@@ -51,7 +54,10 @@ class TestUnrollingTextFeatureDatasetTransformer:
         assert inverse_transformed_features == features
 
     def test_should_unroll_and_inverse_transform_x_y_and_features_using_ndarray(self):
-        data_transformer = UnrollingTextFeatureDatasetTransformer(2)
+        data_transformer = UnrollingTextFeatureDatasetTransformer(
+            2,
+            used_features_indices=[1, 2, 3]
+        )
         x = np.asarray([['token1', 'token2']], dtype='object')
         y = np.asarray([['label1', 'label2']], dtype='object')
         features = np.asarray([[
@@ -76,8 +82,40 @@ class TestUnrollingTextFeatureDatasetTransformer:
         assert inverse_transformed_y.tolist() == y.tolist()
         assert inverse_transformed_features.tolist() == features.tolist()
 
+    def test_should_unroll_and_inv_transform_x_y_and_features_using_ndarray_no_line_status(self):
+        data_transformer = UnrollingTextFeatureDatasetTransformer(
+            2,
+            used_features_indices=[1, 2]
+        )
+        x = np.asarray([['token1', 'token2']], dtype='object')
+        y = np.asarray([['label1', 'label2']], dtype='object')
+        features = np.asarray([[
+            ['0', '1', 'word11 word12'],
+            ['0', '1', 'word21 word22']
+        ]], dtype='object')
+        transformed_x, transformed_y, transformed_features = data_transformer.fit_transform(
+            x, y, features
+        )
+        assert transformed_x.tolist() == [['word11', 'word12', 'word21', 'word22']]
+        assert transformed_y.tolist() == [['label1', 'label1', 'label2', 'label2']]
+        assert transformed_features.tolist() == [[
+            ['0', '1', 'word11 word12'],
+            ['0', '1', 'word11 word12'],
+            ['0', '1', 'word21 word22'],
+            ['0', '1', 'word21 word22']
+        ]]
+        inverse_transformed_x, inverse_transformed_y, inverse_transformed_features = (
+            data_transformer.inverse_transform(transformed_x, transformed_y, transformed_features)
+        )
+        assert inverse_transformed_x.tolist() == x.tolist()
+        assert inverse_transformed_y.tolist() == y.tolist()
+        assert inverse_transformed_features.tolist() == features.tolist()
+
     def test_should_unroll_x_and_features_and_inverse_transform_y(self):
-        data_transformer = UnrollingTextFeatureDatasetTransformer(2)
+        data_transformer = UnrollingTextFeatureDatasetTransformer(
+            2,
+            used_features_indices=[3]
+        )
         x = [['token1', 'token2']]
         y = [['label1', 'label2']]
         features = [[
@@ -115,7 +153,10 @@ class TestUnrollingTextFeatureDatasetTransformer:
         assert inverse_transformed_y == [['label1']]
 
     def test_should_unroll_x_y_and_features_and_inverse_transform_y_with_ib_prefix(self):
-        data_transformer = UnrollingTextFeatureDatasetTransformer(2)
+        data_transformer = UnrollingTextFeatureDatasetTransformer(
+            2,
+            used_features_indices=[3]
+        )
         x = [['token1', 'token2']]
         y = [['B-label1', 'B-label2']]
         features = [[

--- a/tests/sequence_labelling/data_transform/unroll_transform_test.py
+++ b/tests/sequence_labelling/data_transform/unroll_transform_test.py
@@ -122,3 +122,18 @@ class TestUnrollingTextFeatureDatasetTransformer:
             [['O', 'B-label1', 'I-label1', 'B-label2', 'I-label2', 'I-label2']]
         )
         assert inverse_transformed_y == [['B-label1', 'B-label2']]
+
+    def test_should_select_beginning_class_name_only_if_tag_changes(self):
+        data_transformer = UnrollingTextFeatureDatasetTransformer(2)
+        x = [['token1', 'token2']]
+        features = [[
+            [0, 1, 'word11 word12 word13'],
+            [0, 1, 'word21 word22 word23']
+        ]]
+        data_transformer.fit_transform_x_and_features(
+            x, features
+        )
+        inverse_transformed_y = data_transformer.inverse_transform_y(
+            [['B-label1', 'I-label1', 'O', 'B-label1', 'O', 'B-label1']]
+        )
+        assert inverse_transformed_y == [['B-label1', 'I-label1']]

--- a/tests/sequence_labelling/tools/grobid_trainer/utils_test.py
+++ b/tests/sequence_labelling/tools/grobid_trainer/utils_test.py
@@ -418,6 +418,30 @@ class TestGrobidTrainerUtils:
                 embedding_registry_path=default_args['embedding_registry_path']
             )
 
+        @log_on_exception
+        def test_should_be_able_to_train_with_unrolled_text_feature_index(
+                self, default_args: dict, default_model_directory: str):
+            train_eval(
+                **{
+                    **default_args,
+                    'config_props': {
+                        **default_args.get('config_props', {}),
+                        'max_char_length': 60,
+                        'unroll_text_feature_index': 0
+                    }
+                }
+            )
+            model_config = load_model_config(default_model_directory)
+            assert model_config.max_char_length == 60
+            assert model_config.unroll_text_feature_index == 0
+            tag_input(
+                model=default_args['model'],
+                model_path=default_model_directory,
+                input_paths=default_args['input_paths'],
+                download_manager=default_args['download_manager'],
+                embedding_registry_path=default_args['embedding_registry_path']
+            )
+
         @pytest.mark.usefixtures('trainer_mock')
         @pytest.mark.parametrize("copy_preprocessor", [False, True])
         @log_on_exception


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/126

fix for #385

for numpy arrays the line status was added to each feature instead of as an additional column.
also changed behaviour to use beginning prefix if tag has changed.