### PR TITLE
fixed iter_to_data_lines to separate documents

### DIFF
--- a/sciencebeam_trainer_delft/sequence_labelling/tag_formatter.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tag_formatter.py
@@ -67,11 +67,15 @@ def iter_to_data_lines(
     features: np.array,
     annotations: Iterable[List[Tuple[str, str]]]
 ) -> Iterable[str]:
-    return (
-        ' '.join([token_annoation[0]] + list(token_features) + [token_annoation[1]])
-        for line_annotations, line_features in zip(annotations, features.tolist())
-        for token_annoation, token_features in zip(line_annotations, line_features)
-    )
+    for document_lindex, (line_annotations, line_features) in enumerate(
+        zip(annotations, features.tolist())
+    ):
+        if document_lindex > 0:
+            yield ''  # blank line separator
+        yield from (
+            ' '.join([token_annoation[0]] + list(token_features) + [token_annoation[1]])
+            for token_annoation, token_features in zip(line_annotations, line_features)
+        )
 
 
 def to_data_lines(*args, **kwargs) -> List[str]:
@@ -89,8 +93,8 @@ def iter_format_list_tag_result_as_data(
         features=features,
         annotations=tag_result
     )
-    for document_index, data_text in enumerate(data_text_iterable):
-        if document_index > 0:
+    for line_index, data_text in enumerate(data_text_iterable):
+        if line_index > 0:
             yield '\n'
         yield data_text
 

--- a/tests/sequence_labelling/tag_formatter_test.py
+++ b/tests/sequence_labelling/tag_formatter_test.py
@@ -108,6 +108,16 @@ class TestFormatTagResult:
         )
         assert result.splitlines() == DATA_LINES_1
 
+    def test_should_separate_document_data_lines_using_blank_line(self):
+        result = format_tag_result(
+            tag_result=to_iterable(ANNOTATIONS_1 * 2),
+            output_format=TagOutputFormats.DATA,
+            texts=np.asarray(TEXTS_1.tolist() * 2),
+            features=np.asarray(FEATURES_1.tolist() * 2),
+            model_name=MODEL_1
+        )
+        assert result.splitlines() == DATA_LINES_1 + [''] + DATA_LINES_1
+
     def test_should_format_tag_list_result_as_data_unidiff_and_combined_tags(self):
         result = format_tag_result(
             tag_result=to_iterable(


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/154