### PR TITLE
create pypi release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 venv
 build
 data
+dist
 logs
 *.egg-info
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ COPY requirements.dev.txt ./
 RUN if [ "${install_dev}" = "y" ]; then pip install -r requirements.dev.txt; fi
 
 COPY sciencebeam_trainer_delft ./sciencebeam_trainer_delft
-COPY setup.py  MANIFEST.in ./
+COPY README.md MANIFEST.in setup.py ./
 
 COPY config/embedding-registry.json ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,8 @@ COPY config/embedding-registry.json ./
 COPY .flake8 .pylintrc pytest.ini ./
 COPY tests ./tests
 
+COPY scripts/dev ./scripts/dev
+
 # add additional wrapper entrypoint for OVERRIDE_EMBEDDING_URL
 COPY ./docker/entrypoint.sh ${PROJECT_FOLDER}/entrypoint.sh
 ENTRYPOINT ["/opt/sciencebeam-trainer-delft/entrypoint.sh"]

--- a/Dockerfile.grobid
+++ b/Dockerfile.grobid
@@ -53,7 +53,7 @@ RUN pip install -r ${PROJECT_FOLDER}/requirements.delft.txt --no-deps
 COPY sciencebeam_trainer_delft ${PROJECT_FOLDER}/sciencebeam_trainer_delft
 
 # install into venv
-COPY setup.py MANIFEST.in ${PROJECT_FOLDER}/
+COPY README.md MANIFEST.in setup.py ${PROJECT_FOLDER}/
 RUN pip install -e ${PROJECT_FOLDER} --no-deps
 
 # add embedding registry with download locations

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,10 +20,6 @@ elifePipeline {
             }
         }
 
-        stage 'Push package to test.pypi.org', {
-            elifePypiRelease('test')
-        }
-
         stage 'Build and run tests', {
             def actions = [
                 'ci-build-and-test-core': {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,9 @@ elifePipeline {
                     // withCommitStatus({
                     //     sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-test-setup-install"
                     // }, 'ci-test-setup-install', commit)
+                    withCommitStatus({
+                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-push-testpypi"
+                    }, 'ci-push-testpypi', commit)
                 },
                 'ci-build-grobid': {
                     withCommitStatus({

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,25 @@
+import groovy.json.JsonSlurper
+
+@NonCPS
+def jsonToPypirc(String jsonText, String sectionName) {
+    def credentials = new JsonSlurper().parseText(jsonText)
+    echo "Username: ${credentials.username}"
+    return "[${sectionName}]\nusername: ${credentials.username}\npassword: ${credentials.password}"
+}
+
+def withPypiCredentials(String env, String sectionName, doSomething) {
+    try {
+        writeFile(file: '.pypirc', text: jsonToPypirc(sh(
+            script: "vault.sh kv get -format=json secret/containers/pypi/${env} | jq .data.data",
+            returnStdout: true
+        ).trim(), sectionName))
+        doSomething()
+    } finally {
+        sh 'echo > .pypirc'
+    }
+}
+
+
 elifePipeline {
     node('containers-jenkins-plugin') {
         def commit
@@ -39,7 +61,9 @@ elifePipeline {
                     //     sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-test-setup-install"
                     // }, 'ci-test-setup-install', commit)
                     withCommitStatus({
-                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-push-testpypi"
+                        withPypiCredentials 'staging', 'testpypi', {
+                            sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-push-testpypi"
+                        }
                     }, 'ci-push-testpypi', commit)
                 },
                 'ci-build-grobid': {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,9 @@ elifePipeline {
                     withCommitStatus({
                         sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-test-setup-install"
                     }, 'ci-test-setup-install', commit)
+                    withCommitStatus({
+                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-push-testpypi"
+                    }, 'ci-push-testpypi', commit)
                 },
                 'ci-build-grobid': {
                     withCommitStatus({

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,6 @@ def jsonToPypirc(String jsonText, String sectionName) {
 
 def withPypiCredentials(String env, String sectionName, doSomething) {
     try {
-        sh 'rm -rf .pypirc || true'
         writeFile(file: '.pypirc', text: jsonToPypirc(sh(
             script: "vault.sh kv get -format=json secret/containers/pypi/${env} | jq .data.data",
             returnStdout: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,9 +38,6 @@ elifePipeline {
                     // withCommitStatus({
                     //     sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-test-setup-install"
                     // }, 'ci-test-setup-install', commit)
-                    withCommitStatus({
-                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-push-testpypi"
-                    }, 'ci-push-testpypi', commit)
                 },
                 'ci-build-grobid': {
                     withCommitStatus({

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,18 +26,18 @@ elifePipeline {
                     withCommitStatus({
                         sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-build-core"
                     }, 'ci-build-core', commit)
-                    withCommitStatus({
-                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-lint"
-                    }, 'ci-lint', commit)
-                    withCommitStatus({
-                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-pytest-not-slow"
-                    }, 'ci-pytest-not-slow', commit)
-                    withCommitStatus({
-                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-pytest-slow"
-                    }, 'ci-pytest-slow', commit)
-                    withCommitStatus({
-                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-test-setup-install"
-                    }, 'ci-test-setup-install', commit)
+                    // withCommitStatus({
+                    //     sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-lint"
+                    // }, 'ci-lint', commit)
+                    // withCommitStatus({
+                    //     sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-pytest-not-slow"
+                    // }, 'ci-pytest-not-slow', commit)
+                    // withCommitStatus({
+                    //     sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-pytest-slow"
+                    // }, 'ci-pytest-slow', commit)
+                    // withCommitStatus({
+                    //     sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-test-setup-install"
+                    // }, 'ci-test-setup-install', commit)
                     withCommitStatus({
                         sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-push-testpypi"
                     }, 'ci-push-testpypi', commit)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ def jsonToPypirc(String jsonText, String sectionName) {
 
 def withPypiCredentials(String env, String sectionName, doSomething) {
     try {
+        sh 'rm .pypirc'
         writeFile(file: '.pypirc', text: jsonToPypirc(sh(
             script: "vault.sh kv get -format=json secret/containers/pypi/${env} | jq .data.data",
             returnStdout: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ def jsonToPypirc(String jsonText, String sectionName) {
 
 def withPypiCredentials(String env, String sectionName, doSomething) {
     try {
-        sh 'rm .pypirc'
+        sh 'rm .pypirc || true'
         writeFile(file: '.pypirc', text: jsonToPypirc(sh(
             script: "vault.sh kv get -format=json secret/containers/pypi/${env} | jq .data.data",
             returnStdout: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,18 +49,18 @@ elifePipeline {
                     withCommitStatus({
                         sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-build-core"
                     }, 'ci-build-core', commit)
-                    // withCommitStatus({
-                    //     sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-lint"
-                    // }, 'ci-lint', commit)
-                    // withCommitStatus({
-                    //     sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-pytest-not-slow"
-                    // }, 'ci-pytest-not-slow', commit)
-                    // withCommitStatus({
-                    //     sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-pytest-slow"
-                    // }, 'ci-pytest-slow', commit)
-                    // withCommitStatus({
-                    //     sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-test-setup-install"
-                    // }, 'ci-test-setup-install', commit)
+                    withCommitStatus({
+                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-lint"
+                    }, 'ci-lint', commit)
+                    withCommitStatus({
+                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-pytest-not-slow"
+                    }, 'ci-pytest-not-slow', commit)
+                    withCommitStatus({
+                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-pytest-slow"
+                    }, 'ci-pytest-slow', commit)
+                    withCommitStatus({
+                        sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-test-setup-install"
+                    }, 'ci-test-setup-install', commit)
                     withCommitStatus({
                         withPypiCredentials 'staging', 'testpypi', {
                             sh "make IMAGE_TAG=${commit} REVISION=${commit} ci-push-testpypi"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,6 +139,12 @@ elifePipeline {
                 image.tag('latest').push()
                 image.tag(version).push()
             }
+
+            stage 'Push release to pypi', {
+                withPypiCredentials 'prod', 'pypi', {
+                    sh "make IMAGE_TAG=${commit} VERSION=${version} NO_BUILD=y ci-push-pypi"
+                }
+            }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,10 @@ elifePipeline {
             }
         }
 
+        stage 'Push package to test.pypi.org', {
+            elifePypiRelease('test')
+        }
+
         stage 'Build and run tests', {
             def actions = [
                 'ci-build-and-test-core': {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ def jsonToPypirc(String jsonText, String sectionName) {
 
 def withPypiCredentials(String env, String sectionName, doSomething) {
     try {
-        sh 'rm .pypirc || true'
+        sh 'rm -rf .pypirc || true'
         writeFile(file: '.pypirc', text: jsonToPypirc(sh(
             script: "vault.sh kv get -format=json secret/containers/pypi/${env} | jq .data.data",
             returnStdout: true

--- a/Makefile
+++ b/Makefile
@@ -393,6 +393,13 @@ ci-test-setup-install:
 	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" test-setup-install
 
 
+ci-push-testpypi:
+	$(DOCKER_COMPOSE_CI) run --rm \
+		-v $$PWD/.pypirc:/root/.pypirc \
+		delft \
+		./scripts/dev/push-testpypi-commit-version.sh "$(COMMIT)"
+
+
 ci-build-grobid:
 	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" grobid-build
 

--- a/Makefile
+++ b/Makefile
@@ -400,6 +400,13 @@ ci-push-testpypi:
 		./scripts/dev/push-testpypi-commit-version.sh "$(REVISION)"
 
 
+ci-push-pypi:
+	$(DOCKER_COMPOSE_CI) run --rm \
+		-v $$PWD/.pypirc:/root/.pypirc \
+		delft \
+		./scripts/dev/push-pypi-version.sh "$(VERSION)"
+
+
 ci-build-grobid:
 	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" grobid-build
 

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,14 @@ dev-watch-slow:
 dev-test: dev-lint dev-pytest
 
 
+dev-remove-dist:
+	rm -rf ./dist
+
+
+dev-build-dist:
+	$(PYTHON) setup.py sdist bdist_wheel
+
+
 build:
 	$(DOCKER_COMPOSE) build delft
 

--- a/Makefile
+++ b/Makefile
@@ -393,10 +393,6 @@ ci-test-setup-install:
 	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" test-setup-install
 
 
-ci-push-testpypi:
-	@echo "dummy ci-push-testpypi"
-
-
 ci-build-grobid:
 	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" grobid-build
 

--- a/Makefile
+++ b/Makefile
@@ -393,6 +393,10 @@ ci-test-setup-install:
 	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" test-setup-install
 
 
+ci-push-testpypi:
+	@echo "dummy ci-push-testpypi"
+
+
 ci-build-grobid:
 	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" grobid-build
 

--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ ci-push-testpypi:
 	$(DOCKER_COMPOSE_CI) run --rm \
 		-v $$PWD/.pypirc:/root/.pypirc \
 		delft \
-		./scripts/dev/push-testpypi-commit-version.sh "$(COMMIT)"
+		./scripts/dev/push-testpypi-commit-version.sh "$(REVISION)"
 
 
 ci-build-grobid:

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -6,3 +6,4 @@ pytest-watch==4.2.0
 setuptools-scm==6.3.2
 types-requests==2.25.11
 types-six==1.16.2
+twine==3.1.1

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,5 +3,6 @@ mypy==0.910
 pylint==2.8.3
 pytest==6.2.5
 pytest-watch==4.2.0
+setuptools-scm==6.3.2
 types-requests==2.25.11
 types-six==1.16.2

--- a/sciencebeam_trainer_delft/__init__.py
+++ b/sciencebeam_trainer_delft/__init__.py
@@ -1,0 +1,1 @@
+__version__ = 'develop'

--- a/scripts/dev/get-commit-version.sh
+++ b/scripts/dev/get-commit-version.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+version_prefix="$1"
+commit="$2"
+
+log() {
+  echo $@ >> /dev/stderr
+}
+
+if [ -z "$version_prefix" ] || [ -z "$commit" ]; then
+  log "Usage: $0 <version_prefix> <commit>"
+  exit 1
+fi
+
+log "version_prefix=${version_prefix}, commit=${commit}"
+
+short_commit="$(echo $commit | tail -c 8)"
+log "short_commit=${short_commit}"
+
+int_commit="$(bash -c 'echo $((16#'$short_commit'))')"
+log "int_commit=${int_commit}"
+
+version="${version_prefix}${int_commit}"
+log "version=${version}"
+
+echo "${version}"

--- a/scripts/dev/print-version.sh
+++ b/scripts/dev/print-version.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+python -c 'import sciencebeam_trainer_delft; print(sciencebeam_trainer_delft.__version__)'

--- a/scripts/dev/push-pypi-version.sh
+++ b/scripts/dev/push-pypi-version.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+version="$1"
+repository="${2:-pypi}"
+
+if [ -z "$version" ] || [ -z "$repository" ]; then
+  echo "Usage: $0 <version> [<repository>]"
+  exit 1
+fi
+
+echo "version=${version}, repository=${repository}"
+
+cat sciencebeam_trainer_delft/__init__.py
+
+ls -l $HOME/.pypirc
+
+ls -l dist/
+
+twine upload --repository "${repository}" --verbose "dist/sciencebeam_trainer_delft-${version}"*

--- a/scripts/dev/push-testpypi-commit-version.sh
+++ b/scripts/dev/push-testpypi-commit-version.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -e
+
+commit="$1"
+repository="${2:-testpypi}"
+
+if [ -z "$commit" ] || [ -z "$repository" ]; then
+  echo "Usage: $0 <commit> [<repository>]"
+  exit 1
+fi
+
+echo "commit=${commit}, repository=${repository}"
+
+date_version=$(date '+%Y.%-m.%-d')
+version_prefix="${date_version}.dev"
+version=$($(dirname $0)/get-commit-version.sh "${version_prefix}" "${commit}")
+echo 'test'
+echo "version=${version}"
+
+$(dirname $0)/set-version.sh "${version}"
+
+cat sciencebeam_trainer_delft/__init__.py
+
+python setup.py sdist
+
+$(dirname $0)/push-pypi-version.sh "${version}" "${repository}"

--- a/scripts/dev/set-version.sh
+++ b/scripts/dev/set-version.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+version="$1"
+
+sed -i -e "s/^__version__ = .*/__version__ = \"${version}\"/g" sciencebeam_trainer_delft/__init__.py

--- a/scripts/dev/verify-version.sh
+++ b/scripts/dev/verify-version.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_HOME=$(dirname "$0")
+
+version="$1"
+
+actual_version="$("${SCRIPT_HOME}/print-version.sh")"
+
+if [ "${actual_version}" != "${version}" ]; then
+  echo "Version mismatches: ${actual_version} != ${version}"
+  exit 2
+else
+  echo "Version maches (${actual_version})"
+fi

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import os
 import subprocess
 import sys
+from time import time
 
 from distutils.command.build import build  # type: ignore
 
@@ -77,11 +78,20 @@ class CustomBuild(build):
     sub_commands = build.sub_commands + [('CustomCommands', None)]
 
 
+def local_scheme(version):
+    if not version.distance and not version.dirty:
+        return ""
+    return str(int(time()))
+
+
 packages = find_packages()
 
 setup(
     name='sciencebeam_trainer_delft',
-    version='0.0.1',
+    use_scm_version={
+        "local_scheme": local_scheme
+    },
+    setup_requires=['setuptools_scm'],
     install_requires=REQUIRED_PACKAGES,
     packages=packages,
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -96,9 +96,9 @@ setup(
         'build': CustomBuild,
         'CustomCommands': CustomCommands
     },
-    url='https://github.com/elifesciences/sciencebeam-alignment',
+    url='https://github.com/elifesciences/sciencebeam-trainer-delft',
     license='MIT',
-    keywords="sequence alignment",
+    keywords="sciencebeam delft",
     long_description=long_description,
     long_description_content_type='text/markdown'
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 import os
 import subprocess
 import sys
-from time import time
 
 from distutils.command.build import build  # type: ignore
 
@@ -78,20 +77,11 @@ class CustomBuild(build):
     sub_commands = build.sub_commands + [('CustomCommands', None)]
 
 
-def local_scheme(version):
-    if not version.distance and not version.dirty:
-        return ""
-    return str(int(time()))
-
-
 packages = find_packages()
 
 setup(
     name='sciencebeam_trainer_delft',
-    use_scm_version={
-        "local_scheme": local_scheme
-    },
-    setup_requires=['setuptools_scm'],
+    version='0.0.1',
     install_requires=REQUIRED_PACKAGES,
     packages=packages,
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import os
 import subprocess
-import shlex
+import sys
 
 from distutils.command.build import build  # type: ignore
 
@@ -19,8 +19,7 @@ with open(os.path.join('requirements.delft.txt'), 'r') as f:
     DELFT_PACKAGES = f.readlines()
 
 
-def _run_command(command):
-    command_args = shlex.split(command)
+def _run_command(command_args):
     print('Running command: %s' % command_args)
     with subprocess.Popen(
         command_args,
@@ -44,7 +43,10 @@ def _is_delft_installed():
 
 
 def _install_delft():
-    _run_command('pip3 install --no-deps %s' % ' '.join(DELFT_PACKAGES))
+    _run_command(
+        [sys.executable, '-m', 'pip', 'install', '--no-deps']
+        + DELFT_PACKAGES
+    )
 
 
 def _install_delft_if_not_installed():

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,9 @@ from setuptools import (
     Command
 )
 
+import sciencebeam_trainer_delft
+
+
 with open(os.path.join('requirements.txt'), 'r') as f:
     REQUIRED_PACKAGES = f.readlines()
 
@@ -81,7 +84,7 @@ packages = find_packages()
 
 setup(
     name='sciencebeam_trainer_delft',
-    version='0.0.1',
+    version=sciencebeam_trainer_delft.__version__,
     install_requires=REQUIRED_PACKAGES,
     packages=packages,
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ with open(os.path.join('requirements.txt'), 'r') as f:
 with open(os.path.join('requirements.delft.txt'), 'r') as f:
     DELFT_PACKAGES = f.readlines()
 
+with open('README.md', 'r') as f:
+    long_description = f.read()
+
 
 def _run_command(command_args):
     print('Running command: %s' % command_args)
@@ -92,5 +95,10 @@ setup(
     cmdclass={
         'build': CustomBuild,
         'CustomCommands': CustomCommands
-    }
+    },
+    url='https://github.com/elifesciences/sciencebeam-alignment',
+    license='MIT',
+    keywords="sequence alignment",
+    long_description=long_description,
+    long_description_content_type='text/markdown'
 )


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/181

This pushes the package to testpypi (on every PR) and main pypi on tag release.

It uses the slightly verbose approach previously used by `sciencebeam-alignment`. It works for a Dockerized project.
There would be alternatives when using GitHub Actions.

One additional challenge is that we have a dependency on `delft` but do not want all of its requirements (e.g. TensorFlow version).