### PR TITLE
Added tag format and made CLI default to GROBID

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ python -m sciencebeam_trainer_delft.sequence_labelling.grobid_trainer \
     --model-path="data/models/sequenceLabelling/grobid-segmentation" \
     --limit="2" \
     --tag-output-format="data_unidiff" \
+    --tag-label-format="iob" \
     --tag-output-path="/tmp/test.diff"
 ```
 
@@ -593,6 +594,7 @@ python -m sciencebeam_trainer_delft.sequence_labelling.grobid_trainer \
     --model-path="https://github.com/kermitt2/grobid/raw/0.5.6/grobid-home/models/header/" \
     --limit="1" \
     --tag-output-format="data" \
+    --tag-label-format="iob" \
     --quiet \
     | head -5
 ```
@@ -617,6 +619,7 @@ python -m sciencebeam_trainer_delft.sequence_labelling.grobid_trainer \
     --model-path="https://github.com/kermitt2/grobid/raw/0.5.6/grobid-home/models/header/" \
     --limit="2" \
     --tag-output-format="data_unidiff" \
+    --tag-label-format="iob" \
     --tag-output-path="/tmp/test.diff"
 ```
 

--- a/sciencebeam_trainer_delft/sequence_labelling/tag_formatter.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tag_formatter.py
@@ -36,6 +36,17 @@ TAG_OUTPUT_FORMATS = [
     TagOutputFormats.XML_DIFF,
 ]
 
+
+class TagLabelFormats:
+    IOB = 'iob'
+    GROBID = 'grobid'
+
+
+TAG_LABEL_FORMATS = [
+    TagLabelFormats.IOB,
+    TagLabelFormats.GROBID,
+]
+
 T_Token_Label_Tuple = Tuple[str, str]
 T_Document_Token_Label_Tuple_List = Sequence[T_Token_Label_Tuple]
 T_Batch_Token_Label_Tuple_List = Sequence[T_Document_Token_Label_Tuple_List]
@@ -46,6 +57,22 @@ class CustomJsonEncoder(json.JSONEncoder):
         if isinstance(obj, np.ndarray):
             return obj.tolist()
         return json.JSONEncoder.default(self, obj)
+
+
+def translate_tag_label_iob_to_grobid(tag: str) -> str:
+    if tag == 'O':
+        return '<other>'
+    if tag.startswith('B-'):
+        return 'I-' + tag[2:]
+    if tag.startswith('I-'):
+        return tag[2:]
+    return tag
+
+
+def translate_tag_label(tag: str, label_format: str) -> str:
+    if label_format == TagLabelFormats.GROBID:
+        return translate_tag_label_iob_to_grobid(tag)
+    return tag
 
 
 def get_tag_result(
@@ -79,7 +106,8 @@ def format_list_tag_result_as_json(
 
 def iter_to_data_lines(
     features: np.ndarray,
-    annotations: Iterable[List[Tuple[str, str]]]
+    annotations: Iterable[List[Tuple[str, str]]],
+    label_format: str = TagLabelFormats.IOB
 ) -> Iterable[str]:
     for document_lindex, (line_annotations, line_features) in enumerate(
         zip(annotations, features.tolist())
@@ -87,8 +115,12 @@ def iter_to_data_lines(
         if document_lindex > 0:
             yield ''  # blank line separator
         yield from (
-            ' '.join([token_annoation[0]] + list(token_features) + [token_annoation[1]])
-            for token_annoation, token_features in zip(line_annotations, line_features)
+            ' '.join(
+                [token_annotation[0]]
+                + list(token_features)
+                + [translate_tag_label(token_annotation[1], label_format)]
+            )
+            for token_annotation, token_features in zip(line_annotations, line_features)
         )
 
 
@@ -100,12 +132,14 @@ def iter_format_list_tag_result_as_data(
     tag_result: Iterable[List[Tuple[str, str]]],
     texts: Optional[np.ndarray] = None,  # pylint: disable=unused-argument
     features: Optional[np.ndarray] = None,
-    model_name: Optional[str] = None  # pylint: disable=unused-argument
+    model_name: Optional[str] = None,  # pylint: disable=unused-argument
+    label_format: str = TagLabelFormats.IOB
 ) -> Iterable[str]:
     assert features is not None
     data_text_iterable = iter_to_data_lines(
         features=features,
-        annotations=tag_result
+        annotations=tag_result,
+        label_format=label_format
     )
     for line_index, data_text in enumerate(data_text_iterable):
         if line_index > 0:
@@ -161,15 +195,18 @@ def iter_format_document_tag_result_as_data_unidiff(
     document_tag_result: List[Tuple[str, str]],
     document_expected_tag_result: T_Document_Token_Label_Tuple_List,
     document_features: List[List[str]],
-    document_name: str
+    document_name: str,
+    label_format: str = TagLabelFormats.IOB
 ) -> Iterable[str]:
     actual_data = format_list_tag_result_as_data(
         [document_tag_result],
-        features=np.expand_dims(document_features, axis=0)
+        features=np.expand_dims(document_features, axis=0),
+        label_format=label_format
     )
     expected_data = format_list_tag_result_as_data(
         [document_expected_tag_result],
-        features=np.expand_dims(document_features, axis=0)
+        features=np.expand_dims(document_features, axis=0),
+        label_format=label_format
     )
     LOGGER.debug('actual_data: %r', actual_data)
     LOGGER.debug('expected_data: %r', expected_data)
@@ -185,14 +222,16 @@ def iter_format_document_list_tag_result_as_data_unidiff(
     tag_result: Iterable[List[Tuple[str, str]]],
     expected_tag_result: T_Batch_Token_Label_Tuple_List,
     features: T_Batch_Features_Array,
-    document_name_prefix: str
+    document_name_prefix: str,
+    label_format: str = TagLabelFormats.IOB
 ) -> Iterable[str]:
     for document_index, document_tag_result in enumerate(tag_result):
         yield from iter_format_document_tag_result_as_data_unidiff(
             document_tag_result=document_tag_result,
             document_expected_tag_result=expected_tag_result[document_index],
             document_features=features[document_index],
-            document_name='%s%06d' % (document_name_prefix, 1 + document_index)
+            document_name='%s%06d' % (document_name_prefix, 1 + document_index),
+            label_format=label_format
         )
 
 
@@ -201,7 +240,8 @@ def iter_format_list_tag_result_as_data_unidiff(
     expected_tag_result: T_Batch_Token_Label_Tuple_List,
     texts: Optional[np.ndarray] = None,  # pylint: disable=unused-argument
     features: Optional[T_Batch_Features_Array] = None,
-    model_name: Optional[str] = None
+    model_name: Optional[str] = None,
+    label_format: str = TagLabelFormats.IOB
 ) -> Iterable[str]:
     assert expected_tag_result
     assert features is not None
@@ -212,7 +252,8 @@ def iter_format_list_tag_result_as_data_unidiff(
         tag_result=tag_result,
         expected_tag_result=expected_tag_result,
         features=features,
-        document_name_prefix=document_name_prefix
+        document_name_prefix=document_name_prefix,
+        label_format=label_format
     )
 
 
@@ -328,18 +369,22 @@ def iter_format_list_tag_result(
         *args,
         output_format: str,
         expected_tag_result: Optional[T_Batch_Token_Label_Tuple_List] = None,
+        label_format: str = TagLabelFormats.IOB,
         **kwargs) -> Iterable[str]:
     if output_format == TagOutputFormats.JSON:
         yield format_list_tag_result_as_json(*args, **kwargs)
         return
     if output_format == TagOutputFormats.DATA:
-        yield from iter_format_list_tag_result_as_data(*args, **kwargs)
+        yield from iter_format_list_tag_result_as_data(  # type: ignore[misc]
+            *args, label_format=label_format, **kwargs
+        )
         return
     if output_format == TagOutputFormats.DATA_UNIDIFF:
         assert expected_tag_result
         yield from iter_format_list_tag_result_as_data_unidiff(  # type: ignore
             *args,
             expected_tag_result=expected_tag_result,
+            label_format=label_format,
             **kwargs
         )
         return
@@ -366,7 +411,8 @@ def iter_format_tag_result(
     expected_tag_result: Optional[T_Batch_Token_Label_Tuple_List] = None,
     texts: Optional[np.ndarray] = None,
     features: Optional[np.ndarray] = None,
-    model_name: Optional[str] = None
+    model_name: Optional[str] = None,
+    label_format: str = TagLabelFormats.IOB
 ) -> Iterable[str]:
     if isinstance(tag_result, dict):
         assert output_format == TagOutputFormats.JSON
@@ -378,7 +424,8 @@ def iter_format_tag_result(
         expected_tag_result=expected_tag_result,
         texts=texts,
         features=features,
-        model_name=model_name
+        model_name=model_name,
+        label_format=label_format
     )
 
 

--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli.py
@@ -58,6 +58,7 @@ from sciencebeam_trainer_delft.sequence_labelling.tools.grobid_trainer.cli_args 
     add_stateful_argument,
     add_input_window_stride_argument,
     add_tag_output_format_argument,
+    add_tag_label_format_argument,
     add_tag_output_path_argument,
     add_tag_transformed_argument,
     add_model_positional_argument,
@@ -395,6 +396,7 @@ class TagSubCommand(GrobidTrainerSubCommand):
         add_input_window_stride_argument(parser)
         add_model_path_argument(parser, required=True, help='directory to load the model from')
         add_tag_output_format_argument(parser)
+        add_tag_label_format_argument(parser)
         add_tag_output_path_argument(parser)
         add_tag_transformed_argument(parser)
 
@@ -402,6 +404,7 @@ class TagSubCommand(GrobidTrainerSubCommand):
         tag_input(
             model_path=args.model_path,
             tag_output_format=args.tag_output_format,
+            tag_label_format=args.tag_label_format,
             tag_output_path=args.tag_output_path,
             tag_transformed=args.tag_transformed,
             stateful=args.stateful,
@@ -415,6 +418,7 @@ class WapitiTagSubCommand(GrobidTrainerSubCommand):
         add_common_arguments(parser, max_sequence_length_default=None)
         add_model_path_argument(parser, required=True, help='directory to load the model from')
         add_tag_output_format_argument(parser)
+        add_tag_label_format_argument(parser)
         add_tag_output_path_argument(parser)
         add_wapiti_install_arguments(parser)
 
@@ -422,6 +426,7 @@ class WapitiTagSubCommand(GrobidTrainerSubCommand):
         wapiti_tag_input(
             model_path=args.model_path,
             tag_output_format=args.tag_output_format,
+            tag_label_format=args.tag_label_format,
             tag_output_path=args.tag_output_path,
             input_paths=args.input,
             limit=args.limit,

--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli_args.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli_args.py
@@ -29,7 +29,9 @@ from sciencebeam_trainer_delft.sequence_labelling.engines.wapiti import (
 
 from sciencebeam_trainer_delft.sequence_labelling.tag_formatter import (
     TagOutputFormats,
-    TAG_OUTPUT_FORMATS
+    TAG_OUTPUT_FORMATS,
+    TagLabelFormats,
+    TAG_LABEL_FORMATS
 )
 
 from sciencebeam_trainer_delft.sequence_labelling.evaluation import (
@@ -217,6 +219,16 @@ def add_tag_output_format_argument(parser: argparse.ArgumentParser, **kwargs):
         default=DEFAULT_TAG_OUTPUT_FORMAT,
         choices=TAG_OUTPUT_FORMATS,
         help="output format for tag results",
+        **kwargs
+    )
+
+
+def add_tag_label_format_argument(parser: argparse.ArgumentParser, **kwargs):
+    parser.add_argument(
+        "--tag-label-format",
+        default=TagLabelFormats.GROBID,
+        choices=TAG_LABEL_FORMATS,
+        help="label format for tag results",
         **kwargs
     )
 

--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/utils.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/utils.py
@@ -48,6 +48,7 @@ from sciencebeam_trainer_delft.sequence_labelling.engines.wapiti_adapters import
 
 from sciencebeam_trainer_delft.sequence_labelling.tag_formatter import (
     TagOutputFormats,
+    TagLabelFormats,
     get_tag_result,
     iter_format_tag_result
 )
@@ -792,6 +793,7 @@ def wapiti_eval_model(
 def do_tag_input(
     model: Union[Sequence, WapitiModelAdapter],
     tag_output_format: str = DEFAULT_TAG_OUTPUT_FORMAT,
+    tag_label_format: str = TagLabelFormats.GROBID,
     tag_output_path: Optional[str] = None,
     input_paths: Optional[List[str]] = None,
     limit: Optional[int] = None,
@@ -836,7 +838,8 @@ def do_tag_input(
         expected_tag_result=expected_tag_result,
         texts=expected_x_all,
         features=expected_features_all,
-        model_name=model._get_model_name()  # pylint: disable=protected-access
+        model_name=model._get_model_name(),  # pylint: disable=protected-access
+        label_format=tag_label_format
     )
     if tag_output_path:
         LOGGER.info('writing tag results to: %r', tag_output_path)
@@ -856,6 +859,7 @@ def do_tag_input(
 def tag_input(
     model_name: str,
     tag_output_format: str = DEFAULT_TAG_OUTPUT_FORMAT,
+    tag_label_format: str = TagLabelFormats.GROBID,
     tag_output_path: Optional[str] = None,
     input_paths: Optional[List[str]] = None,
     output_path: Optional[str] = None,
@@ -889,6 +893,7 @@ def tag_input(
     do_tag_input(
         model,
         tag_output_format=tag_output_format,
+        tag_label_format=tag_label_format,
         tag_output_path=tag_output_path,
         input_paths=input_paths,
         limit=limit,
@@ -902,6 +907,7 @@ def wapiti_tag_input(
     model_path: str,
     download_manager: DownloadManager,
     tag_output_format: str = DEFAULT_TAG_OUTPUT_FORMAT,
+    tag_label_format: str = TagLabelFormats.GROBID,
     tag_output_path: Optional[str] = None,
     input_paths: Optional[List[str]] = None,
     limit: Optional[int] = None,
@@ -917,6 +923,7 @@ def wapiti_tag_input(
     do_tag_input(
         model=model,
         tag_output_format=tag_output_format,
+        tag_label_format=tag_label_format,
         tag_output_path=tag_output_path,
         input_paths=input_paths,
         limit=limit,

--- a/tests/sequence_labelling/tag_formatter_test.py
+++ b/tests/sequence_labelling/tag_formatter_test.py
@@ -7,8 +7,10 @@ import numpy as np
 
 from sciencebeam_trainer_delft.sequence_labelling.tag_formatter import (
     TagOutputFormats,
+    TagLabelFormats,
     get_tag_result,
     get_xml_tag_for_annotation_label,
+    translate_tag_label_iob_to_grobid,
     format_tag_result as _format_tag_result
 )
 
@@ -75,6 +77,20 @@ class TestGetXmlTagForAnnotationLabel:
         assert get_xml_tag_for_annotation_label('B-<tag>') == 'tag'
 
 
+class TestTranslateTagLabelIobToGrobid:
+    def test_should_convert_begin_tag(self):
+        assert translate_tag_label_iob_to_grobid('B-header') == 'I-header'
+
+    def test_should_convert_inside_tag(self):
+        assert translate_tag_label_iob_to_grobid('I-header') == 'header'
+
+    def test_should_convert_outside_tag(self):
+        assert translate_tag_label_iob_to_grobid('O') == '<other>'
+
+    def test_should_pass_through_unknown_tag(self):
+        assert translate_tag_label_iob_to_grobid('<other>') == '<other>'
+
+
 class TestFormatTagResult:
     def test_should_handle_numpy_arrays_in_text(self):
         tag_result = {
@@ -117,6 +133,43 @@ class TestFormatTagResult:
             model_name=MODEL_1
         )
         assert result.splitlines() == DATA_LINES_1 + [''] + DATA_LINES_1
+
+    def test_should_format_tag_list_result_as_data_with_grobid_label_format(self):
+        result = format_tag_result(
+            tag_result=to_iterable(
+                [[('token1', 'B-header'), ('token2', 'I-header'), ('token3', 'O')]]
+            ),
+            output_format=TagOutputFormats.DATA,
+            features=np.array([[['f1'], ['f2'], ['f3']]]),
+            label_format=TagLabelFormats.GROBID
+        )
+        assert result.splitlines() == [
+            'token1 f1 I-header',
+            'token2 f2 header',
+            'token3 f3 <other>'
+        ]
+
+    def test_should_format_tag_list_result_as_data_unidiff_with_grobid_label_format(self):
+        result = format_tag_result(
+            tag_result=to_iterable(
+                [[('token1', 'B-tag1'), ('token2', 'I-tag1'), ('token3', 'B-tag2')]]
+            ),
+            expected_tag_result=[
+                [('token1', 'B-tag1'), ('token2', 'I-tag1'), ('token3', 'B-tag3')]
+            ],
+            features=np.array([[['f1'], ['f2'], ['f3']]]),
+            output_format=TagOutputFormats.DATA_UNIDIFF,
+            label_format=TagLabelFormats.GROBID
+        )
+        assert result.splitlines() == [
+            '--- document_000001.expected',
+            '+++ document_000001.actual',
+            '@@ -1,3 +1,3 @@',
+            ' token1 f1 I-tag1',
+            ' token2 f2 tag1',
+            '-token3 f3 I-tag3',
+            '+token3 f3 I-tag2'
+        ]
 
     def test_should_format_tag_list_result_as_data_unidiff_and_combined_tags(self):
         result = format_tag_result(


### PR DESCRIPTION
related to https://github.com/eLifePathways/ScienceBeam2.0/issues/61

There is now a new `tag label format` parameter that can be set to `iob` or `grobid` and defaults to `grobid` for the CLI.