### PR TITLE
feat: add --masked-crf-loss flag to CustomBidLSTM_CRF

### DIFF
--- a/sciencebeam_trainer_delft/sequence_labelling/config.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/config.py
@@ -33,6 +33,7 @@ class ModelConfig(_ModelConfig):
         char_input_dropout: float = DEFAULT_CHAR_INPUT_DROPOUT,
         char_lstm_dropout: float = DEFAULT_CHAR_LSTM_DROPOUT,
         stateful: bool = False,
+        masked_crf_loss: bool = False,
         model_version: int = MODEL_VERSION,
         # deprecated
         feature_indices: Optional[List[int]] = None,
@@ -57,6 +58,7 @@ class ModelConfig(_ModelConfig):
         self.char_input_dropout = char_input_dropout
         self.char_lstm_dropout = char_lstm_dropout
         self.stateful = stateful
+        self.masked_crf_loss = masked_crf_loss
         self.model_version = model_version
         for key, val in kwargs.items():
             setattr(self, key, val)

--- a/sciencebeam_trainer_delft/sequence_labelling/models.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/models.py
@@ -9,9 +9,11 @@ from tf_keras.layers import (
     TimeDistributed
 )
 
+import tf_keras.backend as K
+
 import delft.sequenceLabelling.wrapper
 from delft.utilities.crf_wrapper_default import CRFModelWrapperDefault
-from delft.utilities.crf_layer import ChainCRF
+from delft.utilities.crf_layer import ChainCRF, chain_crf_loss
 from delft.sequenceLabelling.models import BaseModel
 from delft.sequenceLabelling.models import get_model as _get_model, BidLSTM_CRF_FEATURES
 
@@ -160,6 +162,26 @@ class CustomBidLSTM_CRF(CustomModel):
         model_inputs.append(length_input)
 
         self.model = Model(inputs=model_inputs, outputs=[pred])
+
+        if config.masked_crf_loss:
+            # Override ChainCRF loss to mask PAD positions (label index 0).
+            # Without masking, PAD tokens (~37% of padded sequences) produce a large
+            # spurious gradient that can overwhelm the learning signal for rare classes.
+            # The mask is derived from y_true: PAD positions have one-hot label 0,
+            # real positions have labels 1..ntags-1.
+            crf_layer = self.crf
+
+            def _masked_chain_crf_loss(y_true, y_pred):
+                y_sparse = K.argmax(y_true, axis=-1)
+                mask = K.cast(K.not_equal(y_sparse, 0), K.floatx())
+                return chain_crf_loss(
+                    y_true, y_pred,
+                    crf_layer.U, crf_layer.b_start, crf_layer.b_end,
+                    mask
+                )
+
+            self.crf.loss = _masked_chain_crf_loss
+
         self.config = config
 
 

--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli.py
@@ -188,7 +188,8 @@ class GrobidTrainerSubCommand(SubCommand):
                 use_features_indices_input=args.use_features_indices_input,
                 continuous_features_indices=args.continuous_features_indices,
                 features_lstm_units=args.features_lstm_units,
-                stateful=args.stateful
+                stateful=args.stateful,
+                masked_crf_loss=args.masked_crf_loss
             ),
             training_props=dict(
                 initial_epoch=args.initial_epoch,

--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli_args.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli_args.py
@@ -433,6 +433,11 @@ def add_train_arguments(parser: argparse.ArgumentParser):
         help="enables masking of zero for the char input"
     )
     parser.add_argument(
+        "--masked-crf-loss", action='store_true',
+        dest="masked_crf_loss",
+        help="mask PAD positions from the CRF loss (excludes padding from gradient)"
+    )
+    parser.add_argument(
         "--char-input-dropout", type=float, default=DEFAULT_CHAR_INPUT_DROPOUT,
         help="dropout for char input"
     )


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/113

Exposes the PAD-masking CRF loss as an opt-in CLI argument rather than
hardcoding it. The default remains the original unmasked behaviour, so
existing training runs are unaffected. Pass --masked-crf-loss to exclude
PAD positions from the CRF gradient during training.