### PR TITLE
feat: add gcloud-ai-custom-job-submit.sh for Vertex AI custom jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,7 +770,18 @@ The following environment variables can be specified:
 
 ## Training in Google's Vertex AI
 
-You can train a model using Google's [Vertex AI](https://cloud.google.com/vertex-ai/) custom jobs. Use the wrapper script, passing gcloud options before `--` and training args after:
+You can train a model using Google's [Vertex AI](https://cloud.google.com/vertex-ai/) custom jobs. e.g.
+
+```bash
+gcloud ai custom-jobs create \
+    --project="your-gcp-project" \
+    --region="us-central1" \
+    --display-name="my_citation_model" \
+    --worker-pool-spec="machine-type=n1-highmem-8,accelerator-type=NVIDIA_TESLA_T4,accelerator-count=1,replica-count=1,container-image-uri=us-central1-docker.pkg.dev/your-gcp-project/ml-containers/sciencebeam-trainer-delft:0.0.40" \
+    --args="python,-m,sciencebeam_trainer_delft.sequence_labelling.grobid_trainer,citation,train_eval,--job-dir=gs://your-job-bucket/path,--auto-resume,--batch-size=900,--no-embedding,--max-sequence-length=100,--input,https://github.com/eLifePathways/sciencebeam-datasets/releases/download/grobid-0.9.0/delft-grobid-0.9.0-citation.train.gz,--early-stopping-patience=10,--architecture=CustomBidLSTM_CRF,--use-features,--feature-indices=9-27,--word-lstm-units=100,--max-epoch=300,--checkpoint=gs://your-model-bucket/citation/checkpoints/my_citation_model,--output=gs://your-model-bucket/citation/models/my_citation_model"
+```
+
+Or using the project's wrapper script, passing gcloud options before `--` and training args after:
 
 ```bash
 ./gcloud-ai-custom-job-submit.sh \

--- a/README.md
+++ b/README.md
@@ -768,51 +768,35 @@ The following environment variables can be specified:
 | `SCIENCEBEAM_DELFT_BATCH_SIZE` | `10` | The batch size to use
 | `SCIENCEBEAM_DELFT_STATEFUL` | *None* (*False*) | Whether to enable stateful mode. This may only work with a batch size of `1`. Note: the stateful mode is currently very slow.
 
-## Training in Google's AI Platform
+## Training in Google's Vertex AI
 
-You can train a model using Google's [AI Platform](https://cloud.google.com/ai-platform/). e.g.
-
-```bash
-gcloud beta ai-platform jobs submit training \
-    --job-dir "gs://your-job-bucket/path" \
-    --scale-tier=custom \
-    --master-machine-type=n1-highmem-8 \
-    --master-accelerator=count=1,type=NVIDIA_TESLA_K80 \
-    --region=europe-west1 \
-    --stream-logs \
-    --module-name sciencebeam_trainer_delft.sequence_labelling.grobid_trainer \
-    --package-path sciencebeam_trainer_delft \
-    -- \
-    header train_eval \
-    --batch-size="16" \
-    --embedding="https://github.com/elifesciences/sciencebeam-models/releases/download/v0.0.1/glove.6B.50d.txt.xz" \
-    --max-sequence-length="500" \
-    --input=https://github.com/elifesciences/sciencebeam-datasets/releases/download/grobid-0.8.2/delft-grobid-0.8.2-header.train.gz \
-    --limit="10000" \
-    --early-stopping-patience="10" \
-    --max-epoch="50"
-```
-
-Or using the project's wrapper script which provides some default values:
+You can train a model using Google's [Vertex AI](https://cloud.google.com/vertex-ai/) custom jobs. Use the wrapper script, passing gcloud options before `--` and training args after:
 
 ```bash
-./gcloud-ai-platform-submit.sh \
-    --job-prefix "my_job_prefix" \
-    --job-dir "gs://your-job-bucket/path" \
-    --scale-tier=custom \
-    --master-machine-type=n1-highmem-8 \
-    --master-accelerator=count=1,type=NVIDIA_TESLA_K80 \
-    --region=europe-west1 \
+./gcloud-ai-custom-job-submit.sh \
+    --project "your-gcp-project" \
+    --region "us-central1" \
+    --display-name "my_citation_model" \
+    --container-image-uri "us-central1-docker.pkg.dev/your-gcp-project/ml-containers/sciencebeam-trainer-delft:0.0.40" \
     -- \
-    header train_eval \
-    --batch-size="16" \
-    --embedding="https://github.com/elifesciences/sciencebeam-models/releases/download/v0.0.1/glove.6B.50d.txt.xz" \
-    --max-sequence-length="500" \
-    --input=https://github.com/elifesciences/sciencebeam-datasets/releases/download/grobid-0.8.2/delft-grobid-0.8.2-header.train.gz \
-    --limit="10000" \
-    --early-stopping-patience="10" \
-    --max-epoch="50"
+    citation train_eval \
+    --job-dir "gs://your-job-bucket/path" \
+    --auto-resume \
+    --batch-size=900 \
+    --no-embedding \
+    --max-sequence-length=100 \
+    --input https://github.com/eLifePathways/sciencebeam-datasets/releases/download/grobid-0.9.0/delft-grobid-0.9.0-citation.train.gz \
+    --early-stopping-patience=10 \
+    --architecture=CustomBidLSTM_CRF \
+    --use-features \
+    --feature-indices=9-27 \
+    --word-lstm-units=100 \
+    --max-epoch=300 \
+    --checkpoint="gs://your-model-bucket/citation/checkpoints/my_citation_model" \
+    --output="gs://your-model-bucket/citation/models/my_citation_model"
 ```
+
+By default a single `n1-highmem-8` machine with one `NVIDIA_TESLA_T4` GPU is used. Pass `--no-accelerator` for a CPU-only job, or override with `--machine-type`, `--accelerator-type`, and `--accelerator-count`.
 
 (Alternatively you can train for free using Google Colab, see Example Notebooks above)
 

--- a/gcloud-ai-custom-job-submit.sh
+++ b/gcloud-ai-custom-job-submit.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -e
+
+echo "args: $@"
+
+MODULE_NAME=sciencebeam_trainer_delft.sequence_labelling.grobid_trainer
+
+PROJECT=""
+REGION=""
+DISPLAY_NAME=""
+CONTAINER_IMAGE_URI=""
+MACHINE_TYPE="n1-highmem-8"
+ACCELERATOR_TYPE="NVIDIA_TESLA_T4"
+ACCELERATOR_COUNT="1"
+NO_ACCELERATOR=false
+
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        --project)
+            PROJECT="$2"; shift; shift ;;
+        --region)
+            REGION="$2"; shift; shift ;;
+        --display-name)
+            DISPLAY_NAME="$2"; shift; shift ;;
+        --container-image-uri)
+            CONTAINER_IMAGE_URI="$2"; shift; shift ;;
+        --machine-type)
+            MACHINE_TYPE="$2"; shift; shift ;;
+        --accelerator-type)
+            ACCELERATOR_TYPE="$2"; shift; shift ;;
+        --accelerator-count)
+            ACCELERATOR_COUNT="$2"; shift; shift ;;
+        --no-accelerator)
+            NO_ACCELERATOR=true; shift ;;
+        --module-name)
+            MODULE_NAME="$2"; shift; shift ;;
+        --)
+            shift; break ;;
+        *)
+            echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+if [ -z "${PROJECT}" ]; then echo "Error: --project is required"; exit 1; fi
+if [ -z "${REGION}" ]; then echo "Error: --region is required"; exit 1; fi
+if [ -z "${CONTAINER_IMAGE_URI}" ]; then echo "Error: --container-image-uri is required"; exit 1; fi
+
+if [ -z "${DISPLAY_NAME}" ]; then
+    DISPLAY_NAME="sciencebeam_$(date +%Y_%m_%d_%H%M%S -u)"
+fi
+
+if [ "${NO_ACCELERATOR}" = "true" ]; then
+    WORKER_POOL_SPEC="machine-type=${MACHINE_TYPE},replica-count=1,container-image-uri=${CONTAINER_IMAGE_URI}"
+else
+    WORKER_POOL_SPEC="machine-type=${MACHINE_TYPE},accelerator-type=${ACCELERATOR_TYPE},accelerator-count=${ACCELERATOR_COUNT},replica-count=1,container-image-uri=${CONTAINER_IMAGE_URI}"
+fi
+
+ARGS_CSV=$(printf '%s\n' "python" "-m" "${MODULE_NAME}" "$@" | paste -sd ',')
+
+echo "DISPLAY_NAME: ${DISPLAY_NAME}"
+echo "CONTAINER_IMAGE_URI: ${CONTAINER_IMAGE_URI}"
+echo "WORKER_POOL_SPEC: ${WORKER_POOL_SPEC}"
+echo "ARGS_CSV: ${ARGS_CSV}"
+echo ""
+
+gcloud ai custom-jobs create \
+    --project="${PROJECT}" \
+    --region="${REGION}" \
+    --display-name="${DISPLAY_NAME}" \
+    --worker-pool-spec="${WORKER_POOL_SPEC}" \
+    --args="${ARGS_CSV}"


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/113

Replaces the old gcloud-ai-platform-submit.sh pattern with the current gcloud ai custom-jobs create API. Accepts training args after -- and comma-joins them with the python -m module prefix for the --args flag. Supports --no-accelerator for CPU-only jobs.