### PR TITLE
feat: add --require-gpu flag and report device info in training notifications

### DIFF
--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli.py
@@ -27,7 +27,8 @@ from sciencebeam_trainer_delft.utils.logging import (
 from sciencebeam_trainer_delft.embedding import EmbeddingManager
 
 from sciencebeam_trainer_delft.sequence_labelling.utils.train_notify import (
-    get_train_notification_manager
+    get_train_notification_manager,
+    check_required_gpu
 )
 
 from sciencebeam_trainer_delft.sequence_labelling.models import patch_get_model
@@ -232,6 +233,14 @@ class TrainSubCommand(GrobidTrainerSubCommand):
     def do_run(self, args: argparse.Namespace):
         if not args.model:
             raise ValueError("model required")
+        tf_info = get_tf_info()
+        LOGGER.info('get_tf_info: %s', tf_info)
+        check_required_gpu(
+            require_gpu=args.require_gpu,
+            tf_info=tf_info,
+            model_path=args.model,
+            train_notification_manager=get_train_notification_manager(args)
+        )
         if args.preload_embedding:
             self.preload_and_validate_embedding(
                 args.preload_embedding,
@@ -241,7 +250,6 @@ class TrainSubCommand(GrobidTrainerSubCommand):
             args.embedding,
             use_word_embeddings=args.use_word_embeddings and not args.resume_train_model_path
         )
-        LOGGER.info('get_tf_info: %s', get_tf_info())
         train(
             embeddings_name=embedding_name,
             **self.get_train_args(args)
@@ -290,6 +298,14 @@ class TrainEvalSubCommand(GrobidTrainerSubCommand):
             raise ValueError("model required")
         if args.fold_count < 1:
             raise ValueError("fold-count should be equal or more than 1")
+        tf_info = get_tf_info()
+        LOGGER.info('get_tf_info: %s', tf_info)
+        check_required_gpu(
+            require_gpu=args.require_gpu,
+            tf_info=tf_info,
+            model_path=args.model,
+            train_notification_manager=get_train_notification_manager(args)
+        )
         if args.preload_embedding:
             self.preload_and_validate_embedding(
                 args.preload_embedding,
@@ -299,7 +315,6 @@ class TrainEvalSubCommand(GrobidTrainerSubCommand):
             args.embedding,
             use_word_embeddings=args.use_word_embeddings and not args.resume_train_model_path
         )
-        LOGGER.info('get_tf_info: %s', get_tf_info())
         train_eval(
             fold_count=args.fold_count,
             embeddings_name=embedding_name,

--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli_args.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/cli_args.py
@@ -292,6 +292,14 @@ def add_input_window_stride_argument(parser: argparse.ArgumentParser, **kwargs):
     )
 
 
+def add_require_gpu_argument(parser: argparse.ArgumentParser):
+    parser.add_argument(
+        "--require-gpu",
+        action="store_true",
+        help="Fail training immediately if no GPU device is available"
+    )
+
+
 def add_train_arguments(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--architecture", default='BidLSTM_CRF',
@@ -477,6 +485,7 @@ def add_train_arguments(parser: argparse.ArgumentParser):
         help="enables auto-resuming training using checkpoints"
     )
     add_transfer_learning_arguments(parser)
+    add_require_gpu_argument(parser)
     add_train_notification_arguments(parser)
 
 

--- a/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/utils.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/tools/grobid_trainer/utils.py
@@ -26,6 +26,10 @@ from sciencebeam_trainer_delft.utils.io import (
     write_text,
     auto_uploading_output_file
 )
+from sciencebeam_trainer_delft.utils.tf import (
+    get_tf_info,
+    get_tf_device_summary
+)
 
 from sciencebeam_trainer_delft.embedding import EmbeddingManager
 
@@ -190,7 +194,8 @@ def notify_model_train_start(
         model_path=model.get_model_output_path(output_path),
         checkpoints_path=model.log_dir,
         resume_train_model_path=model.model_path,
-        initial_epoch=model.training_config.initial_epoch
+        initial_epoch=model.training_config.initial_epoch,
+        device=get_tf_device_summary(get_tf_info())
     )
 
 

--- a/sciencebeam_trainer_delft/sequence_labelling/utils/train_notify.py
+++ b/sciencebeam_trainer_delft/sequence_labelling/utils/train_notify.py
@@ -7,6 +7,10 @@ import requests
 from sciencebeam_trainer_delft.sequence_labelling.evaluation import (
     ClassificationResult
 )
+from sciencebeam_trainer_delft.utils.tf import (
+    get_tf_gpu_devices,
+    get_tf_device_summary
+)
 
 
 LOGGER = logging.getLogger(__name__)
@@ -17,7 +21,8 @@ DEFAULT_TRAIN_START_MESSAGE_FORMAT = '\n'.join([
     'model_path: `{model_path}`',
     'checkpoints_path: `{checkpoints_path}`',
     'resume_train_model_path: `{resume_train_model_path}`',
-    'initial_epoch: `{initial_epoch}`'
+    'initial_epoch: `{initial_epoch}`',
+    'device: `{device}`'
 ])
 
 
@@ -94,14 +99,16 @@ class TrainNotificationManager:
         model_path: str,
         checkpoints_path: Optional[str],
         resume_train_model_path: Optional[str],
-        initial_epoch: int
+        initial_epoch: int,
+        device: Optional[str] = None
     ):
         self.send_notification(
             self.notification_train_start_message,
             model_path=model_path,
             checkpoints_path=checkpoints_path,
             resume_train_model_path=resume_train_model_path,
-            initial_epoch=initial_epoch
+            initial_epoch=initial_epoch,
+            device=device
         )
 
     def notify_success(
@@ -185,3 +192,27 @@ def notify_train_error(
 ):
     if train_notification_manager is not None:
         train_notification_manager.notify_error(**kwargs)
+
+
+class RequiredGpuNotAvailable(RuntimeError):
+    pass
+
+
+def check_required_gpu(
+    require_gpu: bool,
+    tf_info: dict,
+    model_path: str,
+    train_notification_manager: Optional[TrainNotificationManager]
+):
+    if not require_gpu or get_tf_gpu_devices(tf_info):
+        return
+    error_message = (
+        'GPU required (--require-gpu) but none available (device: %s)'
+        % get_tf_device_summary(tf_info)
+    )
+    notify_train_error(
+        train_notification_manager,
+        model_path=model_path,
+        error=error_message
+    )
+    raise RequiredGpuNotAvailable(error_message)

--- a/sciencebeam_trainer_delft/utils/tf.py
+++ b/sciencebeam_trainer_delft/utils/tf.py
@@ -1,3 +1,7 @@
+import re
+from typing import Any, List
+
+
 try:
     from tensorflow import __version__ as tf_version
     from tensorflow.python.client import device_lib as tf_device_lib
@@ -6,8 +10,42 @@ except ImportError:
     tf_device_lib = None
 
 
-def get_tf_info():
+GPU_DEVICE_TYPE = 'GPU'
+
+GPU_PHYSICAL_DEVICE_DESC_NAME_PATTERN = re.compile(r'name:\s*([^,]+)')
+
+
+def get_tf_info() -> dict:
     return {
         'tf_version': tf_version,
         'tf_device_lib': tf_device_lib.list_local_devices() if tf_device_lib else None
     }
+
+
+def get_tf_gpu_devices(tf_info: dict) -> List[Any]:
+    device_list = tf_info.get('tf_device_lib') or []
+    return [
+        device for device in device_list
+        if device.device_type == GPU_DEVICE_TYPE
+    ]
+
+
+def get_gpu_device_name(device: Any) -> str:
+    match = GPU_PHYSICAL_DEVICE_DESC_NAME_PATTERN.search(
+        getattr(device, 'physical_device_desc', '') or ''
+    )
+    if match:
+        return match.group(1)
+    return device.name
+
+
+def get_tf_device_summary(tf_info: dict) -> str:
+    gpu_devices = get_tf_gpu_devices(tf_info)
+    if not gpu_devices:
+        device_part = 'CPU only'
+    else:
+        device_part = 'GPU x%d (%s)' % (
+            len(gpu_devices),
+            ', '.join(get_gpu_device_name(device) for device in gpu_devices)
+        )
+    return '%s [tf: %s]' % (device_part, tf_info.get('tf_version'))

--- a/tests/sequence_labelling/utils/train_notify_test.py
+++ b/tests/sequence_labelling/utils/train_notify_test.py
@@ -1,4 +1,7 @@
 import argparse
+from unittest.mock import MagicMock
+
+import pytest
 
 from sciencebeam_trainer_delft.sequence_labelling.evaluation import (
     ClassificationResult
@@ -8,10 +11,26 @@ from sciencebeam_trainer_delft.sequence_labelling.utils.train_notify import (
     get_rendered_notification_message,
     add_train_notification_arguments,
     get_train_notification_manager,
+    check_required_gpu,
+    RequiredGpuNotAvailable,
+    DEFAULT_TRAIN_START_MESSAGE_FORMAT,
     DEFAULT_TRAIN_EVAL_SUCCESS_MESSAGE_FORMAT,
     DEFAULT_TRAIN_SUCCESS_MESSAGE_FORMAT,
     DEFAULT_TRAIN_ERROR_MESSAGE_FORMAT
 )
+
+
+MODEL_NAME_1 = 'model1'
+
+TF_INFO_WITH_GPU: dict = {
+    'tf_version': '2.17.1',
+    'tf_device_lib': [MagicMock(device_type='GPU', physical_device_desc='name: Tesla T4')]
+}
+
+TF_INFO_WITHOUT_GPU: dict = {
+    'tf_version': '2.17.1',
+    'tf_device_lib': [MagicMock(device_type='CPU')]
+}
 
 
 class TestGetRenderedNotificationMessage:
@@ -24,6 +43,16 @@ class TestGetRenderedNotificationMessage:
             'f1: {classification_result.f1}',
             classification_result=classification_result
         ) == 'f1: 1.0'
+
+    def test_should_not_fail_using_default_train_start_message(self):
+        get_rendered_notification_message(
+            DEFAULT_TRAIN_START_MESSAGE_FORMAT,
+            model_path='model_path',
+            checkpoints_path=None,
+            resume_train_model_path=None,
+            initial_epoch=0,
+            device='CPU only [tf: 2.17.1]'
+        )
 
     def test_should_not_fail_using_default_train_message(self):
         get_rendered_notification_message(
@@ -56,5 +85,54 @@ class TestGetTrainNotificationManager:
         args = parser.parse_args([])
         train_notification_manager = get_train_notification_manager(args)
         assert train_notification_manager is not None
+        train_notification_manager.notify_start(
+            model_path='model_path',
+            checkpoints_path=None,
+            resume_train_model_path=None,
+            initial_epoch=0,
+            device='CPU only [tf: 2.17.1]'
+        )
         train_notification_manager.notify_success(model_path='model_path')
         train_notification_manager.notify_error(model_path='model_path', error='error')
+
+
+class TestCheckRequiredGpu:
+    def test_should_not_fail_if_gpu_not_required(self):
+        check_required_gpu(
+            require_gpu=False,
+            tf_info=TF_INFO_WITHOUT_GPU,
+            model_path=MODEL_NAME_1,
+            train_notification_manager=None
+        )
+
+    def test_should_not_fail_if_gpu_required_and_available(self):
+        check_required_gpu(
+            require_gpu=True,
+            tf_info=TF_INFO_WITH_GPU,
+            model_path=MODEL_NAME_1,
+            train_notification_manager=None
+        )
+
+    def test_should_raise_error_if_gpu_required_but_not_available(self):
+        with pytest.raises(RequiredGpuNotAvailable):
+            check_required_gpu(
+                require_gpu=True,
+                tf_info=TF_INFO_WITHOUT_GPU,
+                model_path=MODEL_NAME_1,
+                train_notification_manager=None
+            )
+
+    def test_should_notify_error_if_gpu_required_but_not_available(self):
+        train_notification_manager = MagicMock()
+        with pytest.raises(RequiredGpuNotAvailable):
+            check_required_gpu(
+                require_gpu=True,
+                tf_info=TF_INFO_WITHOUT_GPU,
+                model_path=MODEL_NAME_1,
+                train_notification_manager=train_notification_manager
+            )
+        train_notification_manager.notify_error.assert_called_once()
+        assert (
+            train_notification_manager.notify_error.call_args.kwargs['model_path']
+            == MODEL_NAME_1
+        )

--- a/tests/utils/tf_test.py
+++ b/tests/utils/tf_test.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from sciencebeam_trainer_delft.utils.tf import (
+    get_tf_gpu_devices,
+    get_tf_device_summary
+)
+
+
+@dataclass
+class FakeDevice:
+    name: str
+    device_type: str
+    physical_device_desc: Optional[str] = None
+
+
+CPU_DEVICE_1 = FakeDevice(name='/device:CPU:0', device_type='CPU')
+
+GPU_DEVICE_1 = FakeDevice(
+    name='/device:GPU:0',
+    device_type='GPU',
+    physical_device_desc='device: 0, name: Tesla T4, pci bus id: 0000:00:04.0'
+)
+
+GPU_DEVICE_2 = FakeDevice(
+    name='/device:GPU:1',
+    device_type='GPU',
+    physical_device_desc='device: 1, name: Tesla T4, pci bus id: 0000:00:05.0'
+)
+
+
+class TestGetTfGpuDevices:
+    def test_should_return_empty_list_without_gpu_devices(self):
+        tf_info = {'tf_version': '2.17.1', 'tf_device_lib': [CPU_DEVICE_1]}
+        assert get_tf_gpu_devices(tf_info) == []
+
+    def test_should_return_gpu_devices_only(self):
+        tf_info = {
+            'tf_version': '2.17.1',
+            'tf_device_lib': [CPU_DEVICE_1, GPU_DEVICE_1]
+        }
+        assert get_tf_gpu_devices(tf_info) == [GPU_DEVICE_1]
+
+    def test_should_return_empty_list_without_device_lib(self):
+        tf_info = {'tf_version': '2.17.1', 'tf_device_lib': None}
+        assert get_tf_gpu_devices(tf_info) == []
+
+
+class TestGetTfDeviceSummary:
+    def test_should_report_cpu_only(self):
+        tf_info = {'tf_version': '2.17.1', 'tf_device_lib': [CPU_DEVICE_1]}
+        assert get_tf_device_summary(tf_info) == 'CPU only [tf: 2.17.1]'
+
+    def test_should_report_single_gpu_with_name(self):
+        tf_info = {
+            'tf_version': '2.17.1',
+            'tf_device_lib': [CPU_DEVICE_1, GPU_DEVICE_1]
+        }
+        assert get_tf_device_summary(tf_info) == 'GPU x1 (Tesla T4) [tf: 2.17.1]'
+
+    def test_should_report_multiple_gpus(self):
+        tf_info = {
+            'tf_version': '2.17.1',
+            'tf_device_lib': [CPU_DEVICE_1, GPU_DEVICE_1, GPU_DEVICE_2]
+        }
+        assert get_tf_device_summary(tf_info) == (
+            'GPU x2 (Tesla T4, Tesla T4) [tf: 2.17.1]'
+        )


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/123

Fails training fast (with a Slack error notification) when --require-gpu is set but no GPU is detected, and adds a device summary (GPU/CPU, TF version) to the training-start notification, to make GPU availability issues on Vertex AI jobs observable instead of silently falling back to CPU.