### PR TITLE
fix: resolve GPU detection failures caused by cuDNN/nvcc dependency gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 venv
 .venv
+.venv-cudnn8-compat
 build
 data
 dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,13 @@ RUN python -m pytest -p no:cacheprovider -m 'slow'
 # main image
 FROM dev AS delft
 
+# TensorFlow's GPU backend dlopen's libcudnn.so.8, but torch pins nvidia-cudnn-cu12==9.x
+# (a different SONAME) and only one version of that package can be installed at a time.
+# Install cuDNN 8 separately (not into the venv) and expose it via LD_LIBRARY_PATH so
+# TensorFlow can find it without disturbing the cuDNN 9 that torch depends on.
+RUN uv pip install --no-deps --target /opt/cudnn8-compat nvidia-cudnn-cu12==8.9.7.29
+ENV LD_LIBRARY_PATH=/opt/cudnn8-compat/nvidia/cudnn/lib:$LD_LIBRARY_PATH
+
 # add additional wrapper entrypoint for OVERRIDE_EMBEDDING_URL
 COPY ./docker/entrypoint.sh ${PROJECT_FOLDER}/entrypoint.sh
 ENTRYPOINT ["/opt/sciencebeam-trainer-delft/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,15 @@ DOCKER_COMPOSE = $(DOCKER_COMPOSE_DEV)
 VENV = .venv
 UV = VIRTUAL_ENV=$(VENV) uv
 PIP = $(UV) pip
-PYTHON = PATH=$(VENV)/bin:$$PATH $(VENV)/bin/python
+
+# TensorFlow's GPU backend dlopen's libcudnn.so.8, but torch pins nvidia-cudnn-cu12==9.x
+# (a different SONAME) and only one version of that package can be installed at a time.
+# We install cuDNN 8 separately (not into the venv) and expose it via LD_LIBRARY_PATH so
+# TensorFlow can find it without disturbing the cuDNN 9 that torch depends on.
+CUDNN8_COMPAT_DIR = .venv-cudnn8-compat
+CUDNN8_COMPAT_VERSION = 8.9.7.29
+
+PYTHON = PATH=$(VENV)/bin:$$PATH LD_LIBRARY_PATH=$(CUDNN8_COMPAT_DIR)/nvidia/cudnn/lib:$$LD_LIBRARY_PATH $(VENV)/bin/python
 
 BATCH_SIZE = 10
 MAX_EPOCH = 1
@@ -78,7 +86,11 @@ dev-install:
 	$(UV) sync --active --frozen --all-extras --all-groups
 
 
-dev-venv: venv-create dev-install
+dev-install-cudnn8-compat:
+	$(UV) pip install --no-deps --target $(CUDNN8_COMPAT_DIR) nvidia-cudnn-cu12==$(CUDNN8_COMPAT_VERSION)
+
+
+dev-venv: venv-create dev-install dev-install-cudnn8-compat
 
 
 dev-flake8:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
 tf = [
     "tensorflow>=2.17.1",
     "wrapt>=1.14.0",
+    # provides libdevice.10.bc, needed by TensorFlow's XLA GPU JIT compiler
+    # (normally pulled in via tensorflow's own `and-cuda` extra, which we don't use)
+    "nvidia-cuda-nvcc-cu12==12.3.107; sys_platform == 'linux'",
 ]
 delft = [
     "delft>=0.4.3",

--- a/uv.lock
+++ b/uv.lock
@@ -942,6 +942,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cuda-nvcc-cu12"
+version = "12.3.107"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/d9/352879c1d749b787b5c068b32673a73ce1cb6c52874b1d2e80044b101485/nvidia_cuda_nvcc_cu12-12.3.107-py3-none-manylinux1_x86_64.whl", hash = "sha256:a3344b94f5e89023fa17e0bbf8fb0dd26d5ef6f4091a5aab08f215e4999eac62", size = 21955316, upload-time = "2024-01-02T17:11:26.693Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a2/7daafa67d342909e144ecf951395bcc0ced2171625020f283d166aacb794/nvidia_cuda_nvcc_cu12-12.3.107-py3-none-manylinux2014_aarch64.whl", hash = "sha256:35de71d29aef2e8699f083e5ef604155a8e1ada614d3ccba796303e8d2252c61", size = 20098690, upload-time = "2024-03-12T20:30:52.242Z" },
+]
+
+[[package]]
 name = "nvidia-cuda-nvrtc-cu12"
 version = "12.4.127"
 source = { registry = "https://pypi.org/simple" }
@@ -1646,6 +1655,7 @@ delft = [
     { name = "delft" },
 ]
 tf = [
+    { name = "nvidia-cuda-nvcc-cu12", marker = "sys_platform == 'linux'" },
     { name = "tensorflow" },
     { name = "wrapt" },
 ]
@@ -1665,6 +1675,7 @@ dev = [
 requires-dist = [
     { name = "delft", marker = "extra == 'delft'", specifier = ">=0.4.3" },
     { name = "jsonpickle", specifier = ">=1.4.1" },
+    { name = "nvidia-cuda-nvcc-cu12", marker = "sys_platform == 'linux' and extra == 'tf'", specifier = "==12.3.107" },
     { name = "tensorflow", marker = "extra == 'tf'", specifier = ">=2.17.1" },
     { name = "wrapt", marker = "extra == 'tf'", specifier = ">=1.14.0" },
 ]


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/123

TensorFlow was silently falling back to CPU on GPU machines: torch pins
nvidia-cudnn-cu12==9.x while TF's GPU backend needs libcudnn.so.8, and
only one version of that package can be installed at a time. Once GPU
detection was fixed, training still failed during JIT compilation
because nvidia-cuda-nvcc-cu12 (needed for libdevice.10.bc) was missing,
since this project doesn't use tensorflow's own `and-cuda` extra.
Installs cuDNN 8 separately (via LD_LIBRARY_PATH) alongside torch's
cuDNN 9, and adds nvidia-cuda-nvcc-cu12 as a direct dependency, so
GPU training jobs actually run on the GPU instead of silently falling
back to CPU or failing at JIT-compile time.
