### PR TITLE
feat: add scripts to capture reference output from TF-trained models

### DIFF
--- a/scripts/reference-capture/README.md
+++ b/scripts/reference-capture/README.md
@@ -1,0 +1,59 @@
+# Reference capture scripts
+
+One-off scripts that record what the TensorFlow implementation outputs, to
+compare the PyTorch port against. They only run while TensorFlow is installed,
+and can be deleted once the migration is finished.
+
+Output goes to `data/reference/`, which is not tracked. To recreate a capture
+afterwards, check out a commit that still depends on TensorFlow and re-run.
+
+## Setup
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+uv sync --all-extras --all-groups --frozen
+```
+
+## Per-token capture
+
+```bash
+PYTHONPATH=. .venv/bin/python scripts/reference-capture/capture_reference_outputs.py \
+  --model-path=https://github.com/elifesciences/sciencebeam-models/releases/download/v0.0.1/2020-10-04-delft-grobid-header-biorxiv-no-word-embedding.tar.gz \
+  --input-path=https://github.com/elifesciences/sciencebeam-datasets/releases/download/v0.0.1/delft-grobid-0.5.6-header.test.gz \
+  --output-path=data/reference/header-2020-10-04 \
+  --limit=3
+```
+
+Writes `inputs.npz` (the tensors fed to the model after preprocessing),
+`pre_crf_logits.npz` (the `dense_ntags` output), `tags.json` (tokens, predicted
+tags, expected tags) and `metadata.json` (model and input URLs, package
+versions, model config, batch shapes).
+
+Add `--max-sequence-length=100 --input-window-stride=50` to capture the
+sliding-window path instead. Predictions differ from the unwindowed run, since
+the model was trained with a sequence length of 3000.
+
+## End-to-end cases
+
+```bash
+PYTHONPATH=. .venv/bin/python scripts/reference-capture/capture_e2e_reference_outputs.py \
+  --output-path=data/reference/e2e
+```
+
+Covers the 12 `delft` cases in
+`tests/e2e/regression/sequence_labelling/tag_using_existing_models_test.yaml`,
+read from that file so the two stay in step. Writes `tagged_output.xml` and
+`eval.json` per case. Use `--case-id=<id>`, repeatable, for a subset.
+
+## Notes
+
+- Several cases score a model against a corpus it was not trained on, so the
+  numbers are low. They are for comparison, not for judging the models.
+- Scoring uses the sequence length and batch size each model records. Segmentation
+  documents reach 11k tokens, so an unbounded sequence length runs out of memory.
+- `PYTHONPATH=.` is needed because the project is not installed into the
+  venv; run from the repository root.
+- The scripts set `TF_USE_LEGACY_KERAS` themselves.
+- Re-runs are byte-identical, so any difference is a difference in behaviour.
+- Models and datasets are cached under `data/download/` after the first run. The
+  four GROBID header models are fetched file by file and are the slow part.

--- a/scripts/reference-capture/capture_e2e_reference_outputs.py
+++ b/scripts/reference-capture/capture_e2e_reference_outputs.py
@@ -1,0 +1,232 @@
+"""Capture tagged output and eval scores for the end-to-end delft cases.
+
+Cases are read from the regression suite's own YAML so the two stay in step.
+Scores are written without the eval report's timestamp, so a re-run is
+byte-identical.
+
+See scripts/reference-capture/README.md for usage.
+"""
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import sciencebeam_trainer_delft.utils.configure_keras  # noqa, pylint: disable=unused-import
+# pylint: disable=wrong-import-order, ungrouped-imports
+
+import yaml
+
+from sciencebeam_trainer_delft.utils.download_manager import DownloadManager
+from sciencebeam_trainer_delft.embedding.manager import EmbeddingManager
+from sciencebeam_trainer_delft.resources.default_config import DEFAULT_RESOURCE_REGISTRY_FILE
+
+from sciencebeam_trainer_delft.sequence_labelling.saving import ModelLoader
+
+from sciencebeam_trainer_delft.sequence_labelling.tools.grobid_trainer.utils import (
+    load_data_and_labels,
+    load_delft_model,
+    tag_input
+)
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+DEFAULT_TEST_DATA_PATH = (
+    'tests/e2e/regression/sequence_labelling/tag_using_existing_models_test.yaml'
+)
+
+TEST_NAME = 'test_tag_using_existing_model'
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Capture reference output for the end-to-end delft cases'
+    )
+    parser.add_argument('--test-data-path', default=DEFAULT_TEST_DATA_PATH)
+    parser.add_argument('--output-path', required=True)
+    parser.add_argument(
+        '--tag-limit', type=int, default=1,
+        help='documents to tag, matching the regression suite'
+    )
+    parser.add_argument(
+        '--eval-limit', type=int, default=20,
+        help='documents to score; fixed rather than large, so the score is reproducible'
+    )
+    parser.add_argument('--batch-size', type=int, default=20)
+    parser.add_argument(
+        '--eval-max-sequence-length', type=int,
+        help="unset by default, meaning the model's own recorded sequence length is used"
+    )
+    parser.add_argument('--case-id', action='append', help='capture only these case ids')
+    return parser.parse_args(argv)
+
+
+def to_builtin(value):
+    """Convert numpy scalars, which the support counts are, to JSON-writable types."""
+    item = getattr(value, 'item', None)
+    if item is not None:
+        return item()
+    raise TypeError(f'unsupported type: {type(value)}')
+
+
+def get_delft_test_cases(test_data_path: str) -> List[dict]:
+    with open(test_data_path, encoding='utf-8') as data_file:
+        test_data = yaml.safe_load(data_file)
+    return [
+        test_case
+        for test_case in test_data[TEST_NAME]
+        if test_case.get('engine', 'delft') == 'delft'
+    ]
+
+
+def get_package_versions() -> Dict[str, str]:
+    from importlib.metadata import (  # pylint: disable=import-outside-toplevel
+        PackageNotFoundError,
+        version
+    )
+
+    def get_version(name: str) -> str:
+        try:
+            return version(name)
+        except PackageNotFoundError:
+            return 'not installed'
+
+    return {
+        name: get_version(name)
+        for name in ['delft', 'tensorflow', 'tf-keras', 'numpy', 'scikit-learn']
+    }
+
+
+def capture_case(
+    test_case: dict,
+    case_output_path: Path,
+    args: argparse.Namespace,
+    download_manager: DownloadManager,
+    embedding_manager: EmbeddingManager
+) -> dict:
+    model_path = test_case['model_path']
+    input_path = test_case['input_path']
+    case_output_path.mkdir(parents=True, exist_ok=True)
+
+    # tagging mirrors the regression suite: same helper, same limit, same format
+    tag_input(
+        model_name='dummy-model-name',
+        model_path=model_path,
+        input_paths=[input_path],
+        download_manager=download_manager,
+        embedding_manager=embedding_manager,
+        limit=args.tag_limit,
+        batch_size=args.batch_size,
+        tag_output_path=str(case_output_path / 'tagged_output.xml'),
+        tag_output_format='xml'
+    )
+
+    model = load_delft_model(
+        model_name='dummy-model-name',
+        model_path=model_path,
+        max_sequence_length=args.eval_max_sequence_length,
+        batch_size=args.batch_size,
+        embedding_manager=embedding_manager
+    )
+
+    # Scoring uses the sequence length and batch size the model itself records,
+    # rather than this tool's defaults: those are what it was trained and
+    # published with. Loading overrides the saved batch size, so re-read the
+    # config from the downloaded directory. Segmentation documents reach 11k
+    # tokens, so an unbounded sequence length here exhausts memory on a batch
+    # that production would never build.
+    saved_model_config = ModelLoader(
+        download_manager=download_manager
+    ).load_model_config_from_directory(model.model_path)
+    if args.eval_max_sequence_length is None:
+        model.max_sequence_length = saved_model_config.max_sequence_length
+    model.model_config.batch_size = saved_model_config.batch_size
+    LOGGER.info(
+        'scoring with max_sequence_length=%s batch_size=%s',
+        model.max_sequence_length, model.model_config.batch_size
+    )
+
+    x_eval, y_eval, features_eval = load_data_and_labels(
+        input_paths=[input_path],
+        limit=args.eval_limit,
+        shuffle_input=False,
+        download_manager=download_manager
+    )
+    classification_result = model.get_evaluation_result(
+        x_eval, y_eval, features=features_eval
+    )
+    eval_json = {
+        'micro_averages': classification_result.micro_averages,
+        'scores': classification_result.scores
+    }
+    (case_output_path / 'eval.json').write_text(
+        json.dumps(eval_json, indent=2, default=to_builtin) + '\n', encoding='utf-8'
+    )
+    LOGGER.info(
+        'case %s: micro f1=%.4f over %d sequences',
+        test_case['id'], classification_result.micro_averages['f1'], len(x_eval)
+    )
+    return {
+        'id': test_case['id'],
+        'model_path': model_path,
+        'input_path': input_path,
+        'architecture': model.model_config.architecture,
+        'eval_sequence_count': len(x_eval),
+        'eval_max_sequence_length': model.max_sequence_length,
+        'eval_batch_size': model.model_config.batch_size,
+        'micro_f1': classification_result.micro_averages['f1']
+    }
+
+
+def capture_e2e_reference_outputs(args: argparse.Namespace):
+    output_path = Path(args.output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    download_manager = DownloadManager()
+    embedding_manager = EmbeddingManager(
+        path=DEFAULT_RESOURCE_REGISTRY_FILE,
+        download_manager=download_manager
+    )
+
+    test_cases = get_delft_test_cases(args.test_data_path)
+    if args.case_id:
+        test_cases = [
+            test_case for test_case in test_cases if test_case['id'] in args.case_id
+        ]
+    LOGGER.info('capturing %d case(s)', len(test_cases))
+
+    summaries = []
+    for index, test_case in enumerate(test_cases, 1):
+        LOGGER.info('[%d/%d] %s', index, len(test_cases), test_case['id'])
+        summaries.append(capture_case(
+            test_case,
+            output_path / test_case['id'],
+            args=args,
+            download_manager=download_manager,
+            embedding_manager=embedding_manager
+        ))
+
+    metadata = {
+        'test_data_path': args.test_data_path,
+        'tag_limit': args.tag_limit,
+        'eval_limit': args.eval_limit,
+        'batch_size': args.batch_size,
+        'eval_max_sequence_length': args.eval_max_sequence_length,
+        'package_versions': get_package_versions(),
+        'cases': summaries
+    }
+    (output_path / 'metadata.json').write_text(
+        json.dumps(metadata, indent=2, default=to_builtin) + '\n', encoding='utf-8'
+    )
+    LOGGER.info('written capture for %d case(s) to %s', len(summaries), output_path)
+
+
+def main(argv: Optional[List[str]] = None):
+    logging.basicConfig(level='INFO')
+    capture_e2e_reference_outputs(parse_args(argv))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/reference-capture/capture_reference_outputs.py
+++ b/scripts/reference-capture/capture_reference_outputs.py
@@ -1,0 +1,229 @@
+"""Capture per-token reference output from a TensorFlow-trained model.
+
+Records, for a small fixed sample: the tensors fed to the model after
+preprocessing, the pre-CRF logits, and the predicted tags. The tensors are
+recorded by observing what the tagger passes to the model, so they are what
+inference uses rather than a reconstruction.
+
+See scripts/reference-capture/README.md for usage.
+"""
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import sciencebeam_trainer_delft.utils.configure_keras  # noqa, pylint: disable=unused-import
+# pylint: disable=wrong-import-order, ungrouped-imports
+
+import numpy as np
+
+from sciencebeam_trainer_delft.utils.download_manager import DownloadManager
+from sciencebeam_trainer_delft.embedding.manager import EmbeddingManager
+from sciencebeam_trainer_delft.resources.default_config import DEFAULT_RESOURCE_REGISTRY_FILE
+
+from sciencebeam_trainer_delft.sequence_labelling.tools.grobid_trainer.utils import (
+    load_data_and_labels,
+    load_delft_model
+)
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+PRE_CRF_LAYER_NAME = 'dense_ntags'
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Capture per-token reference outputs from a TF-trained model'
+    )
+    parser.add_argument('--model-path', required=True, help='model directory or tar.gz URL')
+    parser.add_argument('--input-path', required=True, help='dataset path or URL')
+    parser.add_argument('--output-path', required=True, help='directory to write the capture to')
+    parser.add_argument('--model-name', default='header')
+    parser.add_argument(
+        '--limit', type=int, default=3,
+        help='number of documents to capture (kept small deliberately)'
+    )
+    parser.add_argument(
+        '--max-sequence-length', type=int,
+        help=(
+            'truncate sequences to this length; unset by default, matching the'
+            ' library default, so that whole documents are captured'
+        )
+    )
+    parser.add_argument(
+        '--input-window-stride', type=int,
+        help='capture the sliding-window path, requires --max-sequence-length'
+    )
+    parser.add_argument('--batch-size', type=int, default=20)
+    return parser.parse_args(argv)
+
+
+def get_keras_model(delft_model):
+    keras_model = delft_model.model
+    if not hasattr(keras_model, 'get_layer'):
+        raise ValueError(f'unsupported model type: {type(keras_model)}')
+    return keras_model
+
+
+def get_pre_crf_model(keras_model):
+    from tf_keras.models import Model  # pylint: disable=import-outside-toplevel
+    layer_names = [layer.name for layer in keras_model.layers]
+    if PRE_CRF_LAYER_NAME not in layer_names:
+        raise ValueError(
+            f'no {PRE_CRF_LAYER_NAME!r} layer, cannot capture pre-CRF logits'
+            f' (layers: {layer_names})'
+        )
+    return Model(
+        inputs=keras_model.inputs,
+        outputs=keras_model.get_layer(PRE_CRF_LAYER_NAME).output
+    )
+
+
+def get_input_names(keras_model) -> List[str]:
+    return [
+        # the tensor name carries a ":0" suffix and sometimes a scope prefix
+        tensor.name.split(':')[0].split('/')[-1]
+        for tensor in keras_model.inputs
+    ]
+
+
+def get_package_versions() -> Dict[str, str]:
+    # delft exposes no __version__, so ask the installed distribution metadata
+    from importlib.metadata import (  # pylint: disable=import-outside-toplevel
+        PackageNotFoundError,
+        version
+    )
+
+    def get_version(name: str) -> str:
+        try:
+            return version(name)
+        except PackageNotFoundError:
+            return 'not installed'
+
+    return {
+        name: get_version(name)
+        for name in ['delft', 'tensorflow', 'tf-keras', 'numpy', 'scikit-learn']
+    }
+
+
+def capture_reference_outputs(args: argparse.Namespace):
+    output_path = Path(args.output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    download_manager = DownloadManager()
+    embedding_manager = EmbeddingManager(
+        path=DEFAULT_RESOURCE_REGISTRY_FILE,
+        download_manager=download_manager
+    )
+
+    x_all, y_all, features_all = load_data_and_labels(
+        input_paths=[args.input_path],
+        limit=args.limit,
+        shuffle_input=False,
+        download_manager=download_manager
+    )
+    LOGGER.info('loaded %d documents', len(x_all))
+
+    model = load_delft_model(
+        model_name=args.model_name,
+        model_path=args.model_path,
+        max_sequence_length=args.max_sequence_length,
+        input_window_stride=args.input_window_stride,
+        batch_size=args.batch_size,
+        embedding_manager=embedding_manager
+    )
+    delft_model = model.model
+    keras_model = get_keras_model(delft_model)
+    input_names = get_input_names(keras_model)
+    LOGGER.info('model inputs: %s', input_names)
+
+    pre_crf_model = get_pre_crf_model(keras_model)
+
+    captured_batches: List[List[np.ndarray]] = []
+    original_predict_on_batch = keras_model.predict_on_batch
+
+    def recording_predict_on_batch(inputs):
+        captured_batches.append([np.asarray(item) for item in inputs])
+        return original_predict_on_batch(inputs)
+
+    # shadows the attribute delft's BaseModel would otherwise delegate
+    delft_model.predict_on_batch = recording_predict_on_batch
+
+    tag_result = list(model.iter_tag(
+        x_all, output_format=None, features=features_all
+    ))
+    LOGGER.info('tagged %d documents in %d batch(es)', len(tag_result), len(captured_batches))
+    if not captured_batches:
+        raise AssertionError('no batches were captured')
+
+    input_arrays = {}
+    logit_arrays = {}
+    for batch_index, batch_inputs in enumerate(captured_batches):
+        for name, array in zip(input_names, batch_inputs):
+            input_arrays[f'batch{batch_index:02d}.{name}'] = array
+        logits = np.asarray(pre_crf_model.predict_on_batch(batch_inputs))
+        logit_arrays[f'batch{batch_index:02d}.logits'] = logits
+        LOGGER.info(
+            'batch %d: inputs=%s logits=%s',
+            batch_index,
+            {name: array.shape for name, array in zip(input_names, batch_inputs)},
+            logits.shape
+        )
+
+    np.savez_compressed(output_path / 'inputs.npz', **input_arrays)
+    np.savez_compressed(output_path / 'pre_crf_logits.npz', **logit_arrays)
+
+    tags_json = [
+        {
+            'tokens': [token for token, _ in document],
+            'predicted_tags': [tag for _, tag in document],
+            'expected_tags': list(expected_tags)
+        }
+        for document, expected_tags in zip(tag_result, y_all)
+    ]
+    (output_path / 'tags.json').write_text(
+        json.dumps(tags_json, indent=2) + '\n', encoding='utf-8'
+    )
+
+    model_config = vars(model.model_config)
+    metadata = {
+        'model_path': args.model_path,
+        'input_path': args.input_path,
+        'limit': args.limit,
+        'max_sequence_length': args.max_sequence_length,
+        'input_window_stride': args.input_window_stride,
+        'batch_size': args.batch_size,
+        'package_versions': get_package_versions(),
+        'model_config': {
+            key: value for key, value in sorted(model_config.items())
+            if not key.startswith('_')
+        },
+        'preprocessor': {
+            'vocab_tag': list(model.p.vocab_tag),
+            'vocab_char_size': len(model.p.vocab_char),
+            'return_features': model.p.return_features,
+            'return_casing': model.p.return_casing
+        },
+        'input_names': input_names,
+        'batch_shapes': [
+            {name: list(array.shape) for name, array in zip(input_names, batch_inputs)}
+            for batch_inputs in captured_batches
+        ],
+        'document_token_counts': [len(document) for document in tag_result]
+    }
+    (output_path / 'metadata.json').write_text(
+        json.dumps(metadata, indent=2, default=str) + '\n', encoding='utf-8'
+    )
+    LOGGER.info('written capture to %s', output_path)
+
+
+def main(argv: Optional[List[str]] = None):
+    logging.basicConfig(level='INFO')
+    capture_reference_outputs(parse_args(argv))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/137

The PyTorch migration replaces the Keras architectures, and corpus-level scores cannot tell a faithful port from a subtly wrong one: a mis-transposed kernel still scores plausibly. These record what the current implementation outputs, while TensorFlow is still a dependency.

The per-token script captures the tensors fed to the model after preprocessing, the pre-CRF logits and the predicted tags. The inputs matter as much as the outputs, because without them a preprocessing difference and an architecture difference look the same; they are recorded by observing what the tagger passes to the model rather than by rebuilding a data generator, so they are what inference uses. The cut is before the CRF because the Keras ChainCRF layer Viterbi-decodes at inference and returns one-hot, carrying nothing the tags do not.

The end-to-end script captures tagged output and eval scores for the 12 delft cases in the regression suite, which assert with length regexes such as .{40,} and so pass on confident nonsense of the right shape. It reads the cases from the suite's YAML so the two stay in step, and scores with the sequence length and batch size each model records -- what they were published with, and also a memory constraint, since segmentation documents reach 11k tokens.

They live under scripts/ rather than in the package: they are one-off migration scripts with no call sites, expected to be deleted afterwards, and packaging them would ship them to consumers. Note that the repo's lint targets cover sciencebeam_trainer_delft and tests only, so scripts/ is not linted by make dev-lint.

Output goes to data/reference/, which is not tracked. The scripts are, so a capture can be recreated by checking out a commit that still depends on TensorFlow, rather than committing binary tensors no review can read.

Running them established two things the specs had assumed. Three architectures cover the 12 cases rather than twelve models, and the GROBID header models for 0.5.6, 0.6.0 and 0.7.0 are the same weights -- identical size, identical scores -- so four releases are two distinct models. Eleven of the twelve sit on the ChainCRF path.

Every capture is byte-identical on a re-run, which is what makes it an oracle.